### PR TITLE
Build fix for gcc 4.9.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ MKBOOTIMAGE_INCLUDE_DIRS:=src
 
 CFLAGS += $(foreach includedir,$(MKBOOTIMAGE_INCLUDE_DIRS),-I$(includedir)) \
 	-DMKBOOTIMAGE_VER="\"$(VERSION)\"" \
-	-Wall -Wextra -Wpedantic
+	-Wall -Wextra -Wpedantic \
+	--std=c11
 
 LDLIBS = -lpcre -lelf
 

--- a/src/file/bitstream.c
+++ b/src/file/bitstream.c
@@ -76,11 +76,11 @@ int bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size) {
   fseek(bitfile, -1, SEEK_CUR);
   fread(img_size, 1, 4, bitfile);
 
-  *img_size = __bswap_32(*img_size) + 1;
+  *img_size = __builtin_bswap32(*img_size) + 1;
 
   for (i = 0; i <= *img_size; i += sizeof(chunk)) {
     fread(&chunk, 1, sizeof(chunk), bitfile);
-    rchunk = __bswap_32(chunk);
+    rchunk = __builtin_bswap32(chunk);
     memcpy(dest, &rchunk, sizeof(rchunk));
     dest++;
   }


### PR DESCRIPTION
Using gcc 4.9.2 I got the warning "warning: ISO C99 doesn’t support unnamed structs/unions" as well as an undefined reference for __bswap_32() during linking. Using explicit --std=c11 and __builtin_bswap32() fixes these compiler errors for me. 