### PR TITLE
Fix assumptions about ELF file layout (issue #6)

### DIFF
--- a/src/arch/zynq.c
+++ b/src/arch/zynq.c
@@ -164,6 +164,7 @@ int zynq_init_part_hdr_dtb(bootrom_partition_hdr_t *ihdr,
 int zynq_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
                            bif_node_t *node,
                            uint32_t *size,
+                           uint32_t load,
                            uint32_t entry,
                            uint8_t nbits) {
   /* Handle unused parameters warning */
@@ -176,7 +177,7 @@ int zynq_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
   hdr = (bootrom_partition_hdr_zynq_t*) ihdr;
 
   /* Set the load and execution address */
-  hdr->dest_load_addr = entry;
+  hdr->dest_load_addr = load;
   hdr->dest_exec_addr = entry;
 
   /* set destination device as the only attribute */

--- a/src/arch/zynqmp.c
+++ b/src/arch/zynqmp.c
@@ -234,6 +234,7 @@ int zynqmp_init_part_hdr_default(bootrom_partition_hdr_t *ihdr,
 int zynqmp_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
                              bif_node_t *node,
                              uint32_t *size,
+                             uint32_t load,
                              uint32_t entry,
                              uint8_t nbits) {
   /* Retrieve the header */
@@ -241,7 +242,7 @@ int zynqmp_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
   hdr = (bootrom_partition_hdr_zynqmp_t*) ihdr;
 
   /* Set the load and execution address */
-  hdr->dest_load_addr_lo = entry;
+  hdr->dest_load_addr_lo = load;
   hdr->dest_exec_addr_lo = entry;
 
   /* Size needs to be rounded after conversion to words  */

--- a/src/bootrom.h
+++ b/src/bootrom.h
@@ -307,6 +307,7 @@ typedef struct bootrom_ops_t {
   int (*init_part_hdr_elf)(bootrom_partition_hdr_t*,
                            bif_node_t*,
                            uint32_t *size,
+                           uint32_t load,
                            uint32_t entry,
                            uint8_t nbits);
   int (*init_part_hdr_bitstream)(bootrom_partition_hdr_t*,

--- a/src/file/elf.h
+++ b/src/file/elf.h
@@ -1,20 +1,14 @@
 #ifndef ELF_H
 #define ELF_H
 
-/* Find all ofsets and sizes that will be needed to properly handle the elf
- * file.
- * Returns the error code */
-int elf_find_offsets(const char *fname,
-                     uint8_t *elf_nbits,
-                     uint32_t *elf_start,
-                     uint32_t *elf_entry,
-                     uint32_t *img_size);
-
-/* Returns the appended file size and the elf entry point via arguments.
+/* Returns the appended file size and the elf header info via arguments.
  * The regular return value is the error code. */
-int elf_append(uint32_t *addr,
-               FILE *elffile,
+int elf_append(void *addr,
+               const char *fname,
+               uint32_t img_max_size,
                uint32_t *img_size,
-               uint32_t start);
+               uint8_t *elf_nbits,
+               uint32_t *elf_load,
+               uint32_t *elf_entry);
 
 #endif


### PR DESCRIPTION
Fix handling of several cases in the ELF code:

- the offset between load address and ELF data offset varies by section,

- some loadable sections follow the first non-loadable section,

- load address is different than entry point address.

The first case is encountered at least in some PMUFW ELF files. The
second case is encountered at least in some PMUFW ELF files on Vivado
2018.1.

The elf_find_offsets() function is merged into elf_append() as they are
always called in pairs and having elf_append() continue to work without
libelf calls would have required elf_find_offsets() to pass much more
information for elf_append().

---

I haven't tested this extensively, but with this change I seemed to get bootable images again (PMUFW+FSBL+ATF+u-boot for ZynqMP).