### PR TITLE
Fix incorrect successful exit code on create_boot_image failure

### DIFF
--- a/src/mkbootimage.c
+++ b/src/mkbootimage.c
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
 
   if (ret != BOOTROM_SUCCESS) { /* Error */
     free(file_data);
-    return ofile_size;
+    return EXIT_FAILURE;
   }
 
   ofile = fopen(arguments.bin_filename, "wb");


### PR DESCRIPTION
create_boot_image() may fail with ofile_size == 0. In such a case, the
current main() returns exit code 0.

Fix that by simply always returning EXIT_FAILURE on create_boot_image()
failure.