### PR TITLE
Correctly handle CFLAGS provided on commandline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MKBOOTIMAGE_OBJS:=${MKBOOTIMAGE_SRCS:.c=.o}
 
 MKBOOTIMAGE_INCLUDE_DIRS:=src
 
-CFLAGS += $(foreach includedir,$(MKBOOTIMAGE_INCLUDE_DIRS),-I$(includedir)) \
+override CFLAGS += $(foreach includedir,$(MKBOOTIMAGE_INCLUDE_DIRS),-I$(includedir)) \
 	-DMKBOOTIMAGE_VER="\"$(VERSION)\"" \
 	-Wall -Wextra -Wpedantic \
 	--std=c11


### PR DESCRIPTION
Otherwise this did not play well with build systems that add CFLAGS to the make invocation, i.e. "make CFLAGS=-Wall all". This is the case of the buildroot build system for example.