### PR TITLE
Mark global variable declarations in headers as extern

### DIFF
--- a/src/arch/zynq.h
+++ b/src/arch/zynq.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include "bootrom.h"
 
-bootrom_ops_t zynq_bops;
+extern bootrom_ops_t zynq_bops;
 
 typedef struct bootrom_partition_hdr_zynq_t {
   uint32_t pd_len; /* encrypted partiton data length */

--- a/src/arch/zynqmp.h
+++ b/src/arch/zynqmp.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include "bootrom.h"
 
-bootrom_ops_t zynqmp_bops;
+extern bootrom_ops_t zynqmp_bops;
 
 typedef struct bootrom_partition_hdr_zynqmp_t {
   uint32_t pd_len;


### PR DESCRIPTION
Without the extern keyword, zynq_bops and zynqmp_bops are defined every time the header is included. With GCC 10 (e.g. on current Arch Linux), this leads to a compile error:
```
gcc -Isrc -DMKBOOTIMAGE_VER="\"mkbootimage 2.2-4ee42d7\"" -Wall -Wextra -Wpedantic --std=c11  src/bif.o src/bootrom.o src/common.o src/mkbootimage.o src/arch/common.o src/arch/zynq.o src/arch/zynqmp.o src/file/bitstream.o src/file/elf.o -o mkbootimage -lpcre -lelf
/usr/bin/ld: src/arch/zynq.o:(.data.rel.local+0x0): multiple definition of `zynq_bops'; src/mkbootimage.o:(.bss+0x0): first defined here
/usr/bin/ld: src/arch/zynqmp.o:(.data.rel.local+0x0): multiple definition of `zynqmp_bops'; src/mkbootimage.o:(.bss+0x60): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:27: mkbootimage] Error 1
```

This pull requests marks the variable declarations in the headers as extern, making mkbootimage compile on current toolchains.