### PR TITLE
Enforce coding style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,114 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakStringLiterals: true
+ColumnLimit: 80
+ContinuationIndentWidth: 2
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<src/file/.*/.h>'
+    Priority:        3
+  - Regex:           '^<src/arch/.*/.h>'
+    Priority:        4
+  - Regex:           '^<src/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '.*'
+    Priority:        5
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: false
+IndentPPDirectives: BeforeHash
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: Wrapped
+JavaScriptQuotes: Leave
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 100
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 10000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+TabWidth:        2
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros: [FORMAT]
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -47,7 +47,7 @@ BreakBeforeBraces: Attach
 BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
 BreakStringLiterals: true
-ColumnLimit: 80
+ColumnLimit: 100
 ContinuationIndentWidth: 2
 DeriveLineEnding: true
 DerivePointerAlignment: true
@@ -56,16 +56,18 @@ ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
 IncludeBlocks:   Regroup
 IncludeCategories:
-  - Regex:           '^<src/file/.*/.h>'
-    Priority:        3
-  - Regex:           '^<src/arch/.*/.h>'
-    Priority:        4
-  - Regex:           '^<src/.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
+  - Regex:           '^<st[^/]+.h>'
     Priority:        1
-  - Regex:           '.*'
+  - Regex:           '^<src/file/.*/.h>'
+    Priority:        4
+  - Regex:           '^<src/arch/.*/.h>'
+    Priority:        3
+  - Regex:           '^<src/.*\.h>'
     Priority:        5
+  - Regex:           '^<.*\.h>'
+    Priority:        6
+  - Regex:           '.*'
+    Priority:        2
 IndentCaseLabels: false
 IndentCaseBlocks: false
 IndentGotoLabels: false
@@ -107,8 +109,9 @@ SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
 Standard:        Auto
 TabWidth:        2
+TypenameMacros: ['FORMAT']
 UseCRLF:         false
 UseTab:          Never
-WhitespaceSensitiveMacros: [FORMAT]
+WhitespaceSensitiveMacros: ['FORMAT']
 ...
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,13 @@ name: Test mkbootimage
 on: [push, pull_request]
 jobs:
   test-zynq-mkbootimage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install dependencies
-        run:  sudo apt-get install --yes libelf-dev
+        run: |
+          sudo apt-get install --yes libelf-dev
+          sudo apt-get install --yes clang-format-12
+          clang-format-12 --version
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -14,6 +17,15 @@ jobs:
         run: |
           make
           test -f mkbootimage
+
+      - name: Run formatting tests
+        run: |
+          clang-format-12 -i src/{arch/,file/,}*.{c,h}
+          git diff --exit-code
+          if [ $? -ne 0 ]; then
+            echo The used coding style is not proper
+            exit 1
+          fi
 
       - name: Run integration tests
         run:  tests/tester.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,39 @@
 name: Test mkbootimage
 on: [push, pull_request]
+
 jobs:
+  check-formatting:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get install --yes clang-format-12
+          clang-format-12 --version
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run formatting check
+        run: |
+          clang-format-12 -i src/{arch/,file/,}*.{c,h}
+          git diff --exit-code > formatting.log
+          if [ $? -ne 0 ]; then
+            echo The code formatting is not proper
+            exit 1
+          fi
+
+      - name: Save diff
+        uses: actions/upload-artifact@v2
+        with:
+          name: formatting
+          path: formatting.log
+
   test-zynq-mkbootimage:
     runs-on: ubuntu-20.04
     steps:
       - name: Install dependencies
         run: |
           sudo apt-get install --yes libelf-dev
-          sudo apt-get install --yes clang-format-12
-          clang-format-12 --version
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -17,15 +42,6 @@ jobs:
         run: |
           make
           test -f mkbootimage
-
-      - name: Run formatting tests
-        run: |
-          clang-format-12 -i src/{arch/,file/,}*.{c,h}
-          git diff --exit-code
-          if [ $? -ne 0 ]; then
-            echo The used coding style is not proper
-            exit 1
-          fi
 
       - name: Run integration tests
         run:  tests/tester.sh

--- a/src/arch/common.c
+++ b/src/arch/common.c
@@ -1,11 +1,11 @@
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <stdio.h>
 
+#include <arch/common.h>
 #include <bif.h>
 #include <bootrom.h>
 #include <common.h>
-#include <arch/common.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 
 int bootrom_init_header(bootrom_hdr_t *hdr) {
   unsigned int i = 0;
@@ -18,7 +18,7 @@ int bootrom_init_header(bootrom_hdr_t *hdr) {
 
   /* BootROM does not interpret the field below */
   hdr->src_offset = 0x0; /* Will be filled elsewhere */
-  hdr->img_len = 0x0; /* Will be filled elsewhere */
+  hdr->img_len = 0x0;    /* Will be filled elsewhere */
   hdr->reserved_0 = BOOTROM_RESERVED_0;
   hdr->start_of_exec = 0x0; /* Will be filled elsewhere */
   hdr->total_img_len = 0x0; /* Will be filled elsewhere */
@@ -30,17 +30,15 @@ int bootrom_init_header(bootrom_hdr_t *hdr) {
 void bootrom_calc_hdr_checksum(bootrom_hdr_t *hdr) {
   /* the checksum skips the interupt vector and starts
    * at the width detect field */
-  hdr->checksum = calc_checksum(&(hdr->width_detect),
-                                &(hdr->checksum) - 1);
+  hdr->checksum = calc_checksum(&(hdr->width_detect), &(hdr->checksum) - 1);
 }
 
-int bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
-                             bootrom_offs_t *offs) {
+int bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab, bootrom_offs_t *offs) {
   /* Prepare image header table */
   img_hdr_tab->version = BOOTROM_IMG_VERSION;
-  img_hdr_tab->part_hdr_off = 0x0; /* filled below */
+  img_hdr_tab->part_hdr_off = 0x0;     /* filled below */
   img_hdr_tab->part_img_hdr_off = 0x0; /* filled below */
-  img_hdr_tab->auth_hdr_off = 0x0; /* auth not implemented */
+  img_hdr_tab->auth_hdr_off = 0x0;     /* auth not implemented */
 
   /* The data will be copied to the reserved space later
    * when we know all the required offsets,

--- a/src/arch/common.h
+++ b/src/arch/common.h
@@ -5,7 +5,6 @@
 
 int bootrom_init_header(bootrom_hdr_t*);
 void bootrom_calc_hdr_checksum(bootrom_hdr_t*);
-int bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t*,
-                             bootrom_offs_t*);
+int bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t*, bootrom_offs_t*);
 
 #endif

--- a/src/arch/zynq.c
+++ b/src/arch/zynq.c
@@ -1,22 +1,21 @@
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <gelf.h>
-#include <unistd.h>
-#include <libgen.h>
 
-#include <bif.h>
-#include <bootrom.h>
-
-#include <common.h>
 #include <arch/common.h>
 #include <arch/zynq.h>
+#include <bif.h>
+#include <bootrom.h>
+#include <common.h>
+#include <fcntl.h>
+#include <gelf.h>
+#include <libgen.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 int zynq_bootrom_init_offs(uint32_t *img_ptr, int hdr_count, bootrom_offs_t *offs) {
-  (void)hdr_count;
+  (void) hdr_count;
   /* Copy the image pointer */
   offs->img_ptr = img_ptr;
 
@@ -47,7 +46,8 @@ int zynq_bootrom_init_header(bootrom_hdr_t *hdr, bootrom_offs_t *offs) {
   memset(hdr->user_defined_zynq_0, 0x0, sizeof(hdr->user_defined_zynq_0));
 
   hdr->user_defined_zynq_0[19] = offs->img_hdr_off;
-  hdr->user_defined_zynq_0[20] = offs->part_hdr_off;;
+  hdr->user_defined_zynq_0[20] = offs->part_hdr_off;
+  ;
 
   /* Memory acces ranges - set to full (0x0 - 0xFFFFFFFF range) */
   for (i = 0; i < 256; i++) {
@@ -63,8 +63,8 @@ int zynq_bootrom_init_header(bootrom_hdr_t *hdr, bootrom_offs_t *offs) {
   return BOOTROM_SUCCESS;
 }
 
-int zynq_bootrom_setup_fsbl_at_curr_off(bootrom_hdr_t* hdr,
-                                        bootrom_offs_t* offs,
+int zynq_bootrom_setup_fsbl_at_curr_off(bootrom_hdr_t *hdr,
+                                        bootrom_offs_t *offs,
                                         uint32_t img_len) {
   /* Update the header to point at the bootloader */
   hdr->src_offset = (offs->coff - offs->img_ptr) * sizeof(uint32_t);
@@ -88,7 +88,7 @@ int zynq_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
 
   /* Retrieve the header */
   bootrom_partition_hdr_zynq_t *part_hdr;
-  part_hdr = (bootrom_partition_hdr_zynq_t*) ihdr;
+  part_hdr = (bootrom_partition_hdr_zynq_t *) ihdr;
 
   /* Call the common code */
   bootrom_init_img_hdr_tab(img_hdr_tab, offs);
@@ -104,9 +104,8 @@ int zynq_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
       img_hdr[i].next_img_off = offs->poff + img_hdr_size - offs->img_ptr;
     }
 
-    img_hdr[i].part_hdr_off =
-      (offs->part_hdr_off / sizeof(uint32_t)) +
-      (i * sizeof(bootrom_partition_hdr_t) / sizeof(uint32_t));
+    img_hdr[i].part_hdr_off = (offs->part_hdr_off / sizeof(uint32_t)) +
+                              (i * sizeof(bootrom_partition_hdr_t) / sizeof(uint32_t));
 
     /* Write the actual img_hdr data */
     memcpy(offs->poff, &(img_hdr[i]), sizeof(img_hdr[i]));
@@ -115,8 +114,7 @@ int zynq_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
     part_hdr[i].img_hdr_off = (offs->poff - offs->img_ptr);
 
     /* Calculate the checksum */
-    part_hdr[i].checksum = calc_checksum(&(part_hdr[i].pd_len),
-                                         &(part_hdr[i].checksum) - 1);
+    part_hdr[i].checksum = calc_checksum(&(part_hdr[i].pd_len), &(part_hdr[i].checksum) - 1);
 
     if (i == 0) {
       img_hdr_tab->part_img_hdr_off = (offs->poff - offs->img_ptr);
@@ -139,11 +137,10 @@ int zynq_init_part_hdr_generic(bootrom_partition_hdr_t *ihdr,
                                uint32_t extra_args) {
   /* Retrieve the header */
   bootrom_partition_hdr_zynq_t *hdr;
-  hdr = (bootrom_partition_hdr_zynq_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynq_t *) ihdr;
 
   /* set destination device as the only attribute */
-  hdr->attributes =
-    (0x1 << BOOTROM_PART_ATTR_DEST_DEV_OFF) | extra_args;
+  hdr->attributes = (0x1 << BOOTROM_PART_ATTR_DEST_DEV_OFF) | extra_args;
 
   /* No load/execution address */
   hdr->dest_load_addr = node->load;
@@ -151,13 +148,11 @@ int zynq_init_part_hdr_generic(bootrom_partition_hdr_t *ihdr,
   return BOOTROM_SUCCESS;
 }
 
-int zynq_init_part_hdr_default(bootrom_partition_hdr_t *ihdr,
-                               bif_node_t *node) {
+int zynq_init_part_hdr_default(bootrom_partition_hdr_t *ihdr, bif_node_t *node) {
   return zynq_init_part_hdr_generic(ihdr, node, BINARY_ATTR_GENERAL);
 }
 
-int zynq_init_part_hdr_dtb(bootrom_partition_hdr_t *ihdr,
-                           bif_node_t *node) {
+int zynq_init_part_hdr_dtb(bootrom_partition_hdr_t *ihdr, bif_node_t *node) {
   return zynq_init_part_hdr_generic(ihdr, node, BINARY_ATTR_RAMDISK);
 }
 
@@ -174,7 +169,7 @@ int zynq_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
 
   /* Retrieve the header */
   bootrom_partition_hdr_zynq_t *hdr;
-  hdr = (bootrom_partition_hdr_zynq_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynq_t *) ihdr;
 
   /* Set the load and execution address */
   hdr->dest_load_addr = load;
@@ -186,14 +181,13 @@ int zynq_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
   return BOOTROM_SUCCESS;
 }
 
-int zynq_init_part_hdr_bitstream(bootrom_partition_hdr_t *ihdr,
-                                 bif_node_t *node) {
+int zynq_init_part_hdr_bitstream(bootrom_partition_hdr_t *ihdr, bif_node_t *node) {
   /* Handle unused parameters warning */
   (void) node;
 
   /* Retrieve the header */
   bootrom_partition_hdr_zynq_t *hdr;
-  hdr = (bootrom_partition_hdr_zynq_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynq_t *) ihdr;
 
   /* Set destination device as the only attribute */
   hdr->attributes = BOOTROM_PART_ATTR_DEST_DEV_PL;
@@ -209,7 +203,7 @@ int zynq_init_part_hdr_linux(bootrom_partition_hdr_t *ihdr,
                              linux_image_header_t *img) {
   /* Retrieve the header */
   bootrom_partition_hdr_zynq_t *hdr;
-  hdr = (bootrom_partition_hdr_zynq_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynq_t *) ihdr;
   if (img->type == FILE_LINUX_IMG_TYPE_UIM) {
     hdr->attributes = BINARY_ATTR_LINUX;
   }
@@ -229,15 +223,13 @@ int zynq_init_part_hdr_linux(bootrom_partition_hdr_t *ihdr,
   return BOOTROM_SUCCESS;
 }
 
-int zynq_finish_part_hdr(bootrom_partition_hdr_t *ihdr,
-                         uint32_t *img_size,
-                         bootrom_offs_t *offs) {
+int zynq_finish_part_hdr(bootrom_partition_hdr_t *ihdr, uint32_t *img_size, bootrom_offs_t *offs) {
   /* Retrieve the header */
   bootrom_partition_hdr_zynq_t *hdr;
-  hdr = (bootrom_partition_hdr_zynq_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynq_t *) ihdr;
 
   /* Is bitstream? */
-  if(hdr->attributes == BOOTROM_PART_ATTR_DEST_DEV_PL) {
+  if (hdr->attributes == BOOTROM_PART_ATTR_DEST_DEV_PL) {
     /* For some reason, a noop is appended after bitstream (only for zynq) */
     const uint8_t noop[4] = {0, 0, 0, 0x20};
     memcpy(offs->coff + (*img_size), noop, sizeof(noop));

--- a/src/arch/zynq.h
+++ b/src/arch/zynq.h
@@ -2,13 +2,14 @@
 #define ARCH_ZYNQ_H
 
 #include <stdint.h>
+
 #include "bootrom.h"
 
 extern bootrom_ops_t zynq_bops;
 
 typedef struct bootrom_partition_hdr_zynq_t {
-  uint32_t pd_len; /* encrypted partiton data length */
-  uint32_t ed_len; /* unecrypted data length */
+  uint32_t pd_len;    /* encrypted partiton data length */
+  uint32_t ed_len;    /* unecrypted data length */
   uint32_t total_len; /* total encrypted, padding,expansion, auth length */
 
   uint32_t dest_load_addr; /* RAM addr where the part will be loaded */

--- a/src/arch/zynqmp.c
+++ b/src/arch/zynqmp.c
@@ -1,18 +1,17 @@
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <libgen.h>
 
-#include <bif.h>
-#include <bootrom.h>
-
-#include <common.h>
 #include <arch/common.h>
 #include <arch/zynqmp.h>
+#include <bif.h>
+#include <bootrom.h>
+#include <common.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #define BOOTROM_ZYNQMP_OFFSET_AFTER_HEADERS 0x40
 
@@ -23,11 +22,10 @@ int zynqmp_bootrom_init_offs(uint32_t *img_ptr, int hdr_count, bootrom_offs_t *o
   /* Init constant offsets */
   offs->img_hdr_off = BOOTROM_IMG_HDR_OFF;
   offs->part_hdr_end_off = 0; /* Not needed by zynqmp */
-  offs->part_hdr_off = offs->img_hdr_off + sizeof(bootrom_img_hdr_tab_t)
-                     + sizeof(bootrom_img_hdr_t) * hdr_count;
-  offs->bins_off = offs->part_hdr_off
-                 + sizeof(bootrom_partition_hdr_t) * hdr_count
-                 + BOOTROM_ZYNQMP_OFFSET_AFTER_HEADERS;
+  offs->part_hdr_off =
+    offs->img_hdr_off + sizeof(bootrom_img_hdr_tab_t) + sizeof(bootrom_img_hdr_t) * hdr_count;
+  offs->bins_off = offs->part_hdr_off + sizeof(bootrom_partition_hdr_t) * hdr_count +
+                   BOOTROM_ZYNQMP_OFFSET_AFTER_HEADERS;
 
   /* Move the offset to reserve the space for headers */
   offs->poff = (offs->img_hdr_off) / sizeof(uint32_t) + img_ptr;
@@ -75,8 +73,8 @@ int zynqmp_bootrom_init_header(bootrom_hdr_t *hdr, bootrom_offs_t *offs) {
   return BOOTROM_SUCCESS;
 }
 
-int zynqmp_bootrom_setup_fsbl_at_curr_off(bootrom_hdr_t* hdr,
-                                          bootrom_offs_t* offs,
+int zynqmp_bootrom_setup_fsbl_at_curr_off(bootrom_hdr_t *hdr,
+                                          bootrom_offs_t *offs,
                                           uint32_t img_len) {
   /* Update the header to point at the bootloader */
   hdr->src_offset = (offs->coff - offs->img_ptr) * sizeof(uint32_t);
@@ -106,7 +104,7 @@ int zynqmp_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
   uint32_t img_hdr_size = 0;
 
   bootrom_partition_hdr_zynqmp_t *part_hdr;
-  part_hdr = (bootrom_partition_hdr_zynqmp_t*) ihdr;
+  part_hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
 
   /* Call the common code */
   bootrom_init_img_hdr_tab(img_hdr_tab, offs);
@@ -115,9 +113,8 @@ int zynqmp_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
     img_hdr_size = sizeof(img_hdr[i]) / sizeof(uint32_t);
     memset(&img_hdr[i].padding, 0xFF, sizeof(img_hdr->padding));
 
-    img_hdr[i].part_hdr_off =
-      (offs->part_hdr_off / sizeof(uint32_t)) +
-      (i * sizeof(bootrom_partition_hdr_t) / sizeof(uint32_t));
+    img_hdr[i].part_hdr_off = (offs->part_hdr_off / sizeof(uint32_t)) +
+                              (i * sizeof(bootrom_partition_hdr_t) / sizeof(uint32_t));
 
     /* Calculate the next img hdr offsets */
     if (i + 1 == img_hdr_tab->hdrs_count) {
@@ -130,8 +127,7 @@ int zynqmp_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
     if (i > 0) {
       part_hdr[i - 1].next_part_hdr_off = img_hdr[i].part_hdr_off;
       part_hdr[i - 1].checksum =
-        calc_checksum(&(part_hdr[i - 1].pd_len),
-                      &(part_hdr[i - 1].checksum) - 1);
+        calc_checksum(&(part_hdr[i - 1].pd_len), &(part_hdr[i - 1].checksum) - 1);
     }
 
     /* Write the actual img_hdr data */
@@ -142,8 +138,7 @@ int zynqmp_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
 
     /* Calculate the checksum if this is the last header*/
     if (i + 1 == img_hdr_tab->hdrs_count) {
-      part_hdr[i].checksum = calc_checksum(&(part_hdr[i].pd_len),
-                                           &(part_hdr[i].checksum) - 1);
+      part_hdr[i].checksum = calc_checksum(&(part_hdr[i].pd_len), &(part_hdr[i].checksum) - 1);
     }
 
     if (i == 0) {
@@ -163,8 +158,7 @@ int zynqmp_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
   memset(img_hdr_tab->reserved, 0x0, sizeof(img_hdr_tab->reserved));
 
   /* Recalculate the checksum */
-  img_hdr_tab->checksum = calc_checksum(&img_hdr_tab->version,
-                                        &(img_hdr_tab->checksum) - 1);
+  img_hdr_tab->checksum = calc_checksum(&img_hdr_tab->version, &(img_hdr_tab->checksum) - 1);
 
   return BOOTROM_SUCCESS;
 }
@@ -183,56 +177,55 @@ uint32_t zynqmp_calc_part_hdr_attr(bif_node_t *node) {
     attr |= BOOTROM_PART_ATTR_DEST_DEV_PL;
 
   switch (node->destination_cpu) {
-    case DST_CPU_A53_0:
-      attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_0;
-      break;
-    case DST_CPU_A53_1:
-      attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_1;
-      break;
-    case DST_CPU_A53_2:
-      attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_2;
-      break;
-    case DST_CPU_A53_3:
-      attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_3;
-      break;
-    case DST_CPU_R5_0:
-      attr |= BOOTROM_PART_ATTR_DEST_CPU_R5_0;
-      break;
-    case DST_CPU_R5_1:
-      attr |= BOOTROM_PART_ATTR_DEST_CPU_R5_1;
-      break;
-    case DST_CPU_R5_LOCKSTEP:
-      attr |= BOOTROM_PART_ATTR_DEST_CPU_R5_L;
-      break;
-    default:
-      break;
+  case DST_CPU_A53_0:
+    attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_0;
+    break;
+  case DST_CPU_A53_1:
+    attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_1;
+    break;
+  case DST_CPU_A53_2:
+    attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_2;
+    break;
+  case DST_CPU_A53_3:
+    attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_3;
+    break;
+  case DST_CPU_R5_0:
+    attr |= BOOTROM_PART_ATTR_DEST_CPU_R5_0;
+    break;
+  case DST_CPU_R5_1:
+    attr |= BOOTROM_PART_ATTR_DEST_CPU_R5_1;
+    break;
+  case DST_CPU_R5_LOCKSTEP:
+    attr |= BOOTROM_PART_ATTR_DEST_CPU_R5_L;
+    break;
+  default:
+    break;
   }
 
   switch (node->exception_level) {
-    case EL_0:
-      attr |= BOOTROM_PART_ATTR_EXC_LVL_EL0;
-      break;
-    case EL_1:
-      attr |= BOOTROM_PART_ATTR_EXC_LVL_EL1;
-      break;
-    case EL_2:
-      attr |= BOOTROM_PART_ATTR_EXC_LVL_EL2;
-      break;
-    case EL_3:
-      attr |= BOOTROM_PART_ATTR_EXC_LVL_EL3;
-      break;
-    default:
-      break;
+  case EL_0:
+    attr |= BOOTROM_PART_ATTR_EXC_LVL_EL0;
+    break;
+  case EL_1:
+    attr |= BOOTROM_PART_ATTR_EXC_LVL_EL1;
+    break;
+  case EL_2:
+    attr |= BOOTROM_PART_ATTR_EXC_LVL_EL2;
+    break;
+  case EL_3:
+    attr |= BOOTROM_PART_ATTR_EXC_LVL_EL3;
+    break;
+  default:
+    break;
   }
 
   return attr;
 }
 
-int zynqmp_init_part_hdr_default(bootrom_partition_hdr_t *ihdr,
-                                 bif_node_t *node) {
+int zynqmp_init_part_hdr_default(bootrom_partition_hdr_t *ihdr, bif_node_t *node) {
   /* Retrieve the header */
   bootrom_partition_hdr_zynqmp_t *hdr;
-  hdr = (bootrom_partition_hdr_zynqmp_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
 
   /* set destination device as the only attribute */
   hdr->attributes = zynqmp_calc_part_hdr_attr(node);
@@ -250,7 +243,7 @@ int zynqmp_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
                              uint8_t nbits) {
   /* Retrieve the header */
   bootrom_partition_hdr_zynqmp_t *hdr;
-  hdr = (bootrom_partition_hdr_zynqmp_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
 
   /* Set the load and execution address */
   hdr->dest_load_addr_lo = load;
@@ -281,12 +274,11 @@ int zynqmp_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
   return BOOTROM_SUCCESS;
 }
 
-int zynqmp_init_part_hdr_bitstream(bootrom_partition_hdr_t *ihdr,
-                                   bif_node_t *node) {
+int zynqmp_init_part_hdr_bitstream(bootrom_partition_hdr_t *ihdr, bif_node_t *node) {
   (void) node;
   /* Retrieve the header */
   bootrom_partition_hdr_zynqmp_t *hdr;
-  hdr = (bootrom_partition_hdr_zynqmp_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
 
   /* Set destination device as the only attribute */
   hdr->attributes = zynqmp_calc_part_hdr_attr(node);
@@ -303,7 +295,7 @@ int zynqmp_init_part_hdr_linux(bootrom_partition_hdr_t *ihdr,
                                bif_node_t *node,
                                linux_image_header_t *img) {
   bootrom_partition_hdr_zynqmp_t *hdr;
-  hdr = (bootrom_partition_hdr_zynqmp_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
 
   /* Despite what ug1283 p. 21 says, sometimes attributes need to be zeroed */
   if (img->type == FILE_LINUX_IMG_TYPE_URD) {
@@ -332,7 +324,7 @@ int zynqmp_finish_part_hdr(bootrom_partition_hdr_t *ihdr,
                            bootrom_offs_t *offs) {
   /* Retrieve the header */
   bootrom_partition_hdr_zynqmp_t *hdr;
-  hdr = (bootrom_partition_hdr_zynqmp_t*) ihdr;
+  hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
 
   /* Set lengths to basic img_len if not set earlier */
   if (hdr->pd_len == 0)

--- a/src/arch/zynqmp.h
+++ b/src/arch/zynqmp.h
@@ -2,6 +2,7 @@
 #define ARCH_ZYNQMP_H
 
 #include <stdint.h>
+
 #include "bootrom.h"
 
 extern bootrom_ops_t zynqmp_bops;

--- a/src/bif.c
+++ b/src/bif.c
@@ -13,27 +13,28 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
-#include <errno.h>
-#include <stdarg.h>
-#include <ctype.h>
-#include <stdbool.h>
 
 #include <bif.h>
 #include <common.h>
+#include <ctype.h>
+#include <errno.h>
 
 /* TODO: panic mode support */
 
@@ -71,7 +72,7 @@ int init_bif_cfg(bif_cfg_t *cfg) {
   cfg->nodes_avail = 8;
 
   /* Alloc memory for it */
-  cfg->nodes = malloc(sizeof (bif_node_t) * cfg->nodes_avail);
+  cfg->nodes = malloc(sizeof(bif_node_t) * cfg->nodes_avail);
   if (!cfg->nodes) {
     return -ENOMEM;
   }
@@ -96,14 +97,14 @@ static int init_lexer(lexer_t *lex, const char *fname) {
     return BIF_ERROR_NOFILE;
   }
 
-  lex->fname = malloc(strlen(fname)+1);
+  lex->fname = malloc(strlen(fname) + 1);
   strcpy(lex->fname, fname);
 
   lex->line = lex->column = 1;
   lex->type = 0;
 
   lex->len = lex->cap = 32;
-  lex->buffer = malloc(lex->cap*sizeof(char));
+  lex->buffer = malloc(lex->cap * sizeof(char));
 
   /* Scan a first token
      as the lexer is assumed to always contain a next token
@@ -124,18 +125,29 @@ static int deinit_lexer(lexer_t *lex) {
 
 static inline char *get_token_name(int type) {
   switch (type) {
-  case ':':  return "':' operator";
-  case '{':  return "'{' operator";
-  case '}':  return "'}' operator";
-  case '[':  return "'[' operator";
-  case ']':  return "']' operator";
-  case ',':  return "',' operator";
-  case '=':  return "'=' operator";
-  case '/':  return "'/' operator";
-  case '\\': return "'\\' operator";
+  case ':':
+    return "':' operator";
+  case '{':
+    return "'{' operator";
+  case '}':
+    return "'}' operator";
+  case '[':
+    return "'[' operator";
+  case ']':
+    return "']' operator";
+  case ',':
+    return "',' operator";
+  case '=':
+    return "'=' operator";
+  case '/':
+    return "'/' operator";
+  case '\\':
+    return "'\\' operator";
 
-  case TOKEN_EOF:  return "end of file";
-  case TOKEN_NAME: return "a string";
+  case TOKEN_EOF:
+    return "end of file";
+  case TOKEN_NAME:
+    return "a string";
   }
   return "unknown token";
 }
@@ -157,7 +169,7 @@ static inline int append_token(lexer_t *lex, char ch) {
   lex->len++;
 
   if (lex->len >= lex->cap) {
-    lex->cap = 2*(lex->len);
+    lex->cap = 2 * (lex->len);
     lex->buffer = realloc(lex->buffer, lex->cap);
     if (!lex->buffer) {
       errorf("out of memory\n");
@@ -165,7 +177,7 @@ static inline int append_token(lexer_t *lex, char ch) {
     }
   }
 
-  lex->buffer[lex->len-1] = ch;
+  lex->buffer[lex->len - 1] = ch;
   lex->buffer[lex->len] = '\0';
   return BIF_SUCCESS;
 }
@@ -275,7 +287,7 @@ static int bif_scan(lexer_t *lex) {
     for (;;) {
       ch = fgetc(lex->file);
 
-      if (ch < 0 || strchr(special_chars,  ch) || isspace(ch)) {
+      if (ch < 0 || strchr(special_chars, ch) || isspace(ch)) {
         ungetc(ch, lex->file); /* we don't want that char */
         lex->type = TOKEN_NAME;
         break;
@@ -302,9 +314,7 @@ static inline int bif_expect(lexer_t *lex, int type) {
   int err = bif_consume(lex, type);
 
   if (err == BIF_ERROR_PARSER)
-    perrorf(lex, "expected %s, got %s\n",
-      get_token_name(type),
-      get_token_name(lex->type));
+    perrorf(lex, "expected %s, got %s\n", get_token_name(type), get_token_name(lex->type));
   return err;
 }
 
@@ -376,7 +386,7 @@ static int bif_parse_attribute(lexer_t *lex, bif_cfg_t *cfg, bif_node_t *node) {
   return err;
 }
 
-int bif_parse(const char* fname, bif_cfg_t *cfg) {
+int bif_parse(const char *fname, bif_cfg_t *cfg) {
   int err;
   lexer_t lex;
   bif_node_t node;
@@ -407,11 +417,8 @@ int bif_parse(const char* fname, bif_cfg_t *cfg) {
   return BIF_SUCCESS;
 }
 
-int bif_node_set_attr(lexer_t *lex,
-                      bif_cfg_t *cfg,
-                      bif_node_t *node,
-                      char *attr_name,
-                      char *value) {
+int bif_node_set_attr(
+  lexer_t *lex, bif_cfg_t *cfg, bif_node_t *node, char *attr_name, char *value) {
   /* TODO: parser errors on wrong scans */
 
   if (strcmp(attr_name, "bootloader") == 0) {
@@ -419,7 +426,7 @@ int bif_node_set_attr(lexer_t *lex,
     return BIF_SUCCESS;
   }
 
-  if (strcmp(attr_name, "load") == 0 ) {
+  if (strcmp(attr_name, "load") == 0) {
     if (!value) {
       perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
       return BIF_ERROR_PARSER;
@@ -431,7 +438,7 @@ int bif_node_set_attr(lexer_t *lex,
     return BIF_SUCCESS;
   }
 
-  if (strcmp(attr_name, "offset") == 0 ) {
+  if (strcmp(attr_name, "offset") == 0) {
     if (!value) {
       perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
       return BIF_ERROR_PARSER;
@@ -474,7 +481,7 @@ int bif_node_set_attr(lexer_t *lex,
       return BIF_SUCCESS;
     }
 
-    if (strcmp(attr_name, "destination_device") == 0 ) {
+    if (strcmp(attr_name, "destination_device") == 0) {
       if (!value) {
         perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
         return BIF_ERROR_PARSER;
@@ -491,7 +498,7 @@ int bif_node_set_attr(lexer_t *lex,
       return BIF_SUCCESS;
     }
 
-    if (strcmp(attr_name, "destination_cpu") == 0 ) {
+    if (strcmp(attr_name, "destination_cpu") == 0) {
       if (!value) {
         perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
         return BIF_ERROR_PARSER;
@@ -587,7 +594,7 @@ int bif_cfg_add_node(bif_cfg_t *cfg, bif_node_t *node) {
   /* Allocate more space if needed */
   if (cfg->nodes_num >= cfg->nodes_avail) {
     cfg->nodes_avail *= 2;
-    cfg->nodes = realloc(cfg->nodes, sizeof (bif_node_t) * cfg->nodes_avail);
+    cfg->nodes = realloc(cfg->nodes, sizeof(bif_node_t) * cfg->nodes_avail);
     if (!cfg->nodes) {
       return -ENOMEM;
     }

--- a/src/bif.h
+++ b/src/bif.h
@@ -1,9 +1,10 @@
 #ifndef BIF_PARSER_H
 #define BIF_PARSER_H
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
+
 #include <linux/limits.h>
 
 #define BIF_SUCCESS                0
@@ -14,21 +15,24 @@
 #define BIF_ERROR_UNSUPPORTED_VAL  5
 #define BIF_ERROR_LEXER            6
 
-#define BIF_ARCH_ZYNQ              (1 << 0)
-#define BIF_ARCH_ZYNQMP            (1 << 1)
+#define BIF_ARCH_ZYNQ   (1 << 0)
+#define BIF_ARCH_ZYNQMP (1 << 1)
 
-typedef enum partition_owner_e {
+typedef enum partition_owner_e
+{
   OWNER_FSBL,
   OWNER_UBOOT
 } partition_owner_t;
 
-typedef enum destination_device_e {
+typedef enum destination_device_e
+{
   DST_DEV_UNDEF = -1,
   DST_DEV_PS,
   DST_DEV_PL
 } destination_device_t;
 
-typedef enum destination_cpu_e {
+typedef enum destination_cpu_e
+{
   DST_CPU_UNDEF = -1,
   DST_CPU_A53_0,
   DST_CPU_A53_1,
@@ -39,7 +43,8 @@ typedef enum destination_cpu_e {
   DST_CPU_R5_LOCKSTEP
 } destination_cpu_t;
 
-typedef enum exception_level_e {
+typedef enum exception_level_e
+{
   EL_UNDEF = -1,
   EL_0,
   EL_1,
@@ -47,7 +52,8 @@ typedef enum exception_level_e {
   EL_3
 } exception_level_t;
 
-enum token_type {
+enum token_type
+{
   TOKEN_EOF = 0,
 
   TOKEN_UNKNOWN = 256, /* skip ASCII */
@@ -103,6 +109,6 @@ int deinit_bif_cfg(bif_cfg_t *cfg);
 int bif_cfg_add_node(bif_cfg_t *cfg, bif_node_t *node);
 int bif_node_set_attr(lexer_t *lex, bif_cfg_t *cfg, bif_node_t *node, char *attr_name, char *value);
 
-int bif_parse(const char* fname, bif_cfg_t *cfg);
+int bif_parse(const char *fname, bif_cfg_t *cfg);
 
 #endif /* BIF_PARSER_H */

--- a/src/bootrom.c
+++ b/src/bootrom.c
@@ -13,33 +13,33 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <libgen.h>
-#include <byteswap.h>
 
+#include <arch/common.h>
 #include <bif.h>
 #include <bootrom.h>
+#include <byteswap.h>
 #include <common.h>
-#include <arch/common.h>
-
-#include <file/elf.h>
+#include <fcntl.h>
 #include <file/bitstream.h>
+#include <file/elf.h>
+#include <libgen.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* Returns the offset by which the addr parameter should be moved
  * and partition header info via argument pointers.
@@ -66,7 +66,7 @@ int append_file_to_image(uint32_t *addr,
   img_size_init = *img_size;
   *img_size = 0;
 
-  if(stat(node.fname, &cfile_stat)) {
+  if (stat(node.fname, &cfile_stat)) {
     errorf("could not stat file: %s\n", node.fname);
     return -BOOTROM_ERROR_NOFILE;
   }
@@ -84,7 +84,7 @@ int append_file_to_image(uint32_t *addr,
   /* Check file format */
   fread(&file_header, 1, sizeof(file_header), cfile);
 
-  switch(file_header) {
+  switch (file_header) {
   case FILE_MAGIC_ELF:
     /* Init elf file (img_size_init is non-zero for a bootloader if there
      * is PMU firmware waiting). File size is used as result size limit
@@ -174,8 +174,7 @@ int append_file_to_image(uint32_t *addr,
 }
 
 /* Returns an estimation of the output image size */
-uint32_t estimate_boot_image_size(bif_cfg_t *bif_cfg)
-{
+uint32_t estimate_boot_image_size(bif_cfg_t *bif_cfg) {
   uint8_t i;
   uint32_t estimated_size;
   struct stat st_file;
@@ -268,7 +267,7 @@ int create_boot_image(uint32_t *img_ptr,
       memset(pmufw_img, 0x00, sizeof(pmufw_img));
 
       /* Open pmu file */
-      if(stat(bif_cfg->nodes[i].fname, &pmufile_stat)) {
+      if (stat(bif_cfg->nodes[i].fname, &pmufile_stat)) {
         errorf("could not stat file: %s\n", bif_cfg->nodes[i].fname);
         return -BOOTROM_ERROR_NOFILE;
       }
@@ -296,7 +295,7 @@ int create_boot_image(uint32_t *img_ptr,
       return -BOOTROM_ERROR_SEC_OVERLAP;
     } else {
       /* Add 0xFF padding until this binary */
-      while (offs.coff < (bif_cfg->nodes[i].offset / sizeof(uint32_t) + img_ptr) ) {
+      while (offs.coff < (bif_cfg->nodes[i].offset / sizeof(uint32_t) + img_ptr)) {
         memset(offs.coff, 0xFF, sizeof(uint32_t));
         offs.coff++;
       }
@@ -311,12 +310,8 @@ int create_boot_image(uint32_t *img_ptr,
       img_size = 0;
     }
 
-    ret = append_file_to_image(offs.coff,
-                               bops,
-                               &offs,
-                               bif_cfg->nodes[i],
-                               &(part_hdr[f]),
-                               &img_size);
+    ret =
+      append_file_to_image(offs.coff, bops, &offs, bif_cfg->nodes[i], &(part_hdr[f]), &img_size);
 
     if (ret != BOOTROM_SUCCESS) {
       return ret;
@@ -324,9 +319,7 @@ int create_boot_image(uint32_t *img_ptr,
 
     /* Check if dealing with bootloader (size is in words - thus x 4) */
     if (bif_cfg->nodes[i].bootloader) {
-      bops->setup_fsbl_at_curr_off(&hdr,
-                                   &offs,
-                                   (part_hdr[f].pd_len * 4) - hdr.pmufw_len);
+      bops->setup_fsbl_at_curr_off(&hdr, &offs, (part_hdr[f].pd_len * 4) - hdr.pmufw_len);
     }
 
     /* Update the offset, skip padding for the last image */
@@ -351,14 +344,14 @@ int create_boot_image(uint32_t *img_ptr,
     /* Calculate number of string terminators, this should be 32b
      * however if the name length is divisible by 4 the bootgen
      * binary makes it 64b and thats what we're going to do here */
-    if (strlen((char*)img_name) % 4 == 0) {
+    if (strlen((char *) img_name) % 4 == 0) {
       img_term_n = 2;
     } else {
       img_term_n = 1;
     }
 
     /* Make the name len be divisible by 4 */
-    while(img_hdr[f].name_len % 4)
+    while (img_hdr[f].name_len % 4)
       img_hdr[f].name_len++;
 
     /* The name is packed in big-endian order. To reconstruct
@@ -372,12 +365,11 @@ int create_boot_image(uint32_t *img_ptr,
     }
 
     /* Append the actual terminators */
-    memset(&(img_hdr[f].name[img_hdr[f].name_len]),
-           0x00, img_term_n * sizeof(uint32_t));
+    memset(&(img_hdr[f].name[img_hdr[f].name_len]), 0x00, img_term_n * sizeof(uint32_t));
 
     /* Fill the rest with 0xFF padding */
-    for (j = img_hdr[f].name_len + img_term_n * sizeof(uint32_t);
-         j < BOOTROM_IMG_MAX_NAME_LEN; j++) {
+    for (j = img_hdr[f].name_len + img_term_n * sizeof(uint32_t); j < BOOTROM_IMG_MAX_NAME_LEN;
+         j++) {
       img_hdr[f].name[j] = 0xFF;
     }
 
@@ -391,16 +383,13 @@ int create_boot_image(uint32_t *img_ptr,
   }
 
   /* Create the image header table */
-  bops->init_img_hdr_tab(&img_hdr_tab,
-                         img_hdr,
-                         part_hdr,
-                         &offs);
+  bops->init_img_hdr_tab(&img_hdr_tab, img_hdr, part_hdr, &offs);
 
   /* Copy the image header as all the fields should be filled by now */
   memcpy(offs.hoff, &(img_hdr_tab), sizeof(img_hdr_tab));
 
   /* Add 0xFF padding until partition header offset */
-  while ((uint32_t)(offs.poff - img_ptr) < offs.part_hdr_off / sizeof(uint32_t)) {
+  while ((uint32_t) (offs.poff - img_ptr) < offs.part_hdr_off / sizeof(uint32_t)) {
     memset(offs.poff, 0xFF, sizeof(uint32_t));
     offs.poff++;
   }
@@ -423,20 +412,19 @@ int create_boot_image(uint32_t *img_ptr,
 
   /* Recalculate partition hdr end offset/padding */
   if (offs.part_hdr_end_off) {
-    offs.part_hdr_end_off =
-      BOOTROM_PART_HDR_OFF
-      + (img_hdr_tab.hdrs_count * sizeof(struct bootrom_partition_hdr_t))
-      + BOOTROM_PART_HDR_END_PADD;
+    offs.part_hdr_end_off = BOOTROM_PART_HDR_OFF +
+                            (img_hdr_tab.hdrs_count * sizeof(struct bootrom_partition_hdr_t)) +
+                            BOOTROM_PART_HDR_END_PADD;
   }
 
   /* Add 0x00 padding until end of partition header */
-  while ((uint32_t)(offs.poff - img_ptr) < offs.part_hdr_end_off / sizeof(uint32_t)) {
+  while ((uint32_t) (offs.poff - img_ptr) < offs.part_hdr_end_off / sizeof(uint32_t)) {
     memset(offs.poff, 0x00, sizeof(uint32_t));
     offs.poff++;
   }
 
   /* Add 0xFF padding until BOOTROM_BINS_OFF */
-  while ((uint32_t)(offs.poff - img_ptr) < offs.bins_off / sizeof(uint32_t) ) {
+  while ((uint32_t) (offs.poff - img_ptr) < offs.bins_off / sizeof(uint32_t)) {
     memset(offs.poff, 0xFF, sizeof(uint32_t));
     offs.poff++;
   }

--- a/src/bootrom.h
+++ b/src/bootrom.h
@@ -1,17 +1,17 @@
 #ifndef BOOTROM_H
 #define BOOTROM_H
 
-#include <gelf.h>
 #include <bif.h>
+#include <gelf.h>
 
-#define BOOTROM_SUCCESS 0
-#define BOOTROM_ERROR_NOFILE 1
-#define BOOTROM_ERROR_BITSTREAM 2
-#define BOOTROM_ERROR_ELF 3
+#define BOOTROM_SUCCESS           0
+#define BOOTROM_ERROR_NOFILE      1
+#define BOOTROM_ERROR_BITSTREAM   2
+#define BOOTROM_ERROR_ELF         3
 #define BOOTROM_ERROR_SEC_OVERLAP 4
 #define BOOTROM_ERROR_UNSUPPORTED 5
-#define BOOTROM_ERROR_NOMEM 6
-#define BOOTROM_ERROR_WADDR 7
+#define BOOTROM_ERROR_NOMEM       6
+#define BOOTROM_ERROR_WADDR       7
 
 /* BootROM Header based on ug585 and ug1085 */
 typedef struct bootrom_hdr_t {
@@ -80,9 +80,9 @@ typedef struct bootrom_hdr_t {
 typedef struct bootrom_img_hdr_tab_t {
   uint32_t version;
   uint32_t hdrs_count;
-  uint32_t part_hdr_off; /* word offset to the partition header */
+  uint32_t part_hdr_off;     /* word offset to the partition header */
   uint32_t part_img_hdr_off; /* word offset to first image header */
-  uint32_t auth_hdr_off; /* word offset to header authentication */
+  uint32_t auth_hdr_off;     /* word offset to header authentication */
   union {
     /* just padding for zynq */
     uint32_t padding[11];
@@ -122,8 +122,8 @@ typedef struct bootrom_img_hdr_t {
    * actual partition count, however the bootgen binary
    * always sets this field to 1. */
   uint32_t name_len;
-  uint8_t  name[BOOTROM_IMG_MAX_NAME_LEN];
-  uint8_t  padding[16];
+  uint8_t name[BOOTROM_IMG_MAX_NAME_LEN];
+  uint8_t padding[16];
 } bootrom_img_hdr_t;
 
 typedef struct linux_image_header_t {
@@ -142,15 +142,15 @@ typedef struct linux_image_header_t {
 } linux_image_header_t;
 
 /* attributes of the bootrom partition header */
-#define BOOTROM_PART_ATTR_OWNER_OFF      16
-#define BOOTROM_PART_ATTR_OWNER_MASK     (3 << BOOTROM_PART_ATTR_OWNER_OFF)
-#define BOOTROM_PART_ATTR_OWNER_FSBL     (0 << BOOTROM_PART_ATTR_OWNER_OFF)
-#define BOOTROM_PART_ATTR_OWNER_UBOOT    (1 << BOOTROM_PART_ATTR_OWNER_OFF)
+#define BOOTROM_PART_ATTR_OWNER_OFF   16
+#define BOOTROM_PART_ATTR_OWNER_MASK  (3 << BOOTROM_PART_ATTR_OWNER_OFF)
+#define BOOTROM_PART_ATTR_OWNER_FSBL  (0 << BOOTROM_PART_ATTR_OWNER_OFF)
+#define BOOTROM_PART_ATTR_OWNER_UBOOT (1 << BOOTROM_PART_ATTR_OWNER_OFF)
 
-#define BOOTROM_PART_ATTR_RSA_USED_OFF   15
-#define BOOTROM_PART_ATTR_RSA_USED_MASK  (1 << BOOTROM_PATR_ATTR_RSA_USED_OFF)
-#define BOOTROM_PART_ATTR_RSA_USED       (1 << BOOTROM_PART_ATTR_RSA_USED_OFF)
-#define BOOTROM_PART_ATTR_RSA_NOT_USED   (0 << BOOTROM_PART_ATTR_RSA_USED_OFF)
+#define BOOTROM_PART_ATTR_RSA_USED_OFF  15
+#define BOOTROM_PART_ATTR_RSA_USED_MASK (1 << BOOTROM_PATR_ATTR_RSA_USED_OFF)
+#define BOOTROM_PART_ATTR_RSA_USED      (1 << BOOTROM_PART_ATTR_RSA_USED_OFF)
+#define BOOTROM_PART_ATTR_RSA_NOT_USED  (0 << BOOTROM_PART_ATTR_RSA_USED_OFF)
 
 #define BOOTROM_PART_ATTR_DEST_CPU_OFF   8
 #define BOOTROM_PART_ATTR_DEST_CPU_NONE  (0 << BOOTROM_PART_ATTR_DEST_CPU_OFF)
@@ -166,23 +166,23 @@ typedef struct linux_image_header_t {
 #define BOOTROM_PART_ATTR_ENCRYPTION_YES (1 << BOOTROM_PART_ATTR_ENCRYPTION_OFF)
 #define BOOTROM_PART_ATTR_ENCRYPTION_NO  (0 << BOOTROM_PART_ATTR_ENCRYPTION_OFF)
 
-#define BOOTROM_PART_ATTR_DEST_DEV_OFF   4
-#define BOOTROM_PART_ATTR_DEST_DEV_MASK  (7 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
-#define BOOTROM_PART_ATTR_DEST_DEV_NONE  (0 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
-#define BOOTROM_PART_ATTR_DEST_DEV_PS    (1 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
-#define BOOTROM_PART_ATTR_DEST_DEV_PL    (2 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
-#define BOOTROM_PART_ATTR_DEST_DEV_INT   (3 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
+#define BOOTROM_PART_ATTR_DEST_DEV_OFF  4
+#define BOOTROM_PART_ATTR_DEST_DEV_MASK (7 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
+#define BOOTROM_PART_ATTR_DEST_DEV_NONE (0 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
+#define BOOTROM_PART_ATTR_DEST_DEV_PS   (1 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
+#define BOOTROM_PART_ATTR_DEST_DEV_PL   (2 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
+#define BOOTROM_PART_ATTR_DEST_DEV_INT  (3 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
 
 #define BOOTROM_PART_ATTR_A5X_EXEC_S_OFF 3
 #define BOOTROM_PART_ATTR_A5X_EXEC_S_64  (0 << BOOTROM_PART_ATTR_A5X_EXEC_S_OFF)
 #define BOOTROM_PART_ATTR_A5X_EXEC_S_32  (1 << BOOTROM_PART_ATTR_A5X_EXEC_S_OFF)
 
-#define BOOTROM_PART_ATTR_EXC_LVL_OFF    1
-#define BOOTROM_PART_ATTR_EXC_LVL_MASK   (0x3 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
-#define BOOTROM_PART_ATTR_EXC_LVL_EL0    (0 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
-#define BOOTROM_PART_ATTR_EXC_LVL_EL1    (1 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
-#define BOOTROM_PART_ATTR_EXC_LVL_EL2    (2 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
-#define BOOTROM_PART_ATTR_EXC_LVL_EL3    (3 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
+#define BOOTROM_PART_ATTR_EXC_LVL_OFF  1
+#define BOOTROM_PART_ATTR_EXC_LVL_MASK (0x3 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
+#define BOOTROM_PART_ATTR_EXC_LVL_EL0  (0 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
+#define BOOTROM_PART_ATTR_EXC_LVL_EL1  (1 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
+#define BOOTROM_PART_ATTR_EXC_LVL_EL2  (2 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
+#define BOOTROM_PART_ATTR_EXC_LVL_EL3  (3 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
 
 #define BOOTROM_PART_ATTR_TRUST_ZONE_OFF 0
 #define BOOTROM_PART_ATTR_TRUST_ZONE_YES (1 << BOOTROM_PART_ATTR_TRUST_ZONE_OFF)
@@ -195,14 +195,14 @@ typedef struct linux_image_header_t {
 #define BOOTROM_RESERVED_ZMP_RL   0x01000020 /* The same as img version? */
 
 /* user defined 0 / fsbl execution address */
-#define BOOTROM_USER_0            0x01010000 /* used by zynq */
-#define BOOTROM_FSBL_EXEC_ADDR    0xfffc0000 /* used by zynqmp */
+#define BOOTROM_USER_0         0x01010000 /* used by zynq */
+#define BOOTROM_FSBL_EXEC_ADDR 0xfffc0000 /* used by zynqmp */
 
 /* PMU firmware related */
 /* The maximum PMU FW size should be 0x00020000 (128kB)
  * according to the TRM, but for some reason bootgen uses
  * the value used below */
-#define BOOTROM_PMUFW_MAX_SIZE    0x0001fae0
+#define BOOTROM_PMUFW_MAX_SIZE 0x0001fae0
 
 /* these values are also taken from bootm.bin
  * however these might not be the only valid
@@ -214,21 +214,21 @@ typedef struct linux_image_header_t {
 #define BOOTROM_BINS_OFF          0x00001700
 
 /* The same defines as above but for zynqmp */
-#define BOOTROM_BINS_OFF_ZMP      0x00000b40
+#define BOOTROM_BINS_OFF_ZMP 0x00000b40
 
 /* values from the documentation */
-#define BOOTROM_WIDTH_DETECT      0xAA995566
-#define BOOTROM_IMG_ID            "XNLX"
-#define BOOTROM_ENCRYPTED_EFUSE   0xA5C3C5A3
-#define BOOTROM_ENCRYPTED_OEFUSE  0xA5C3C5A7 /* obfuscated key in eFUSE */
-#define BOOTROM_ENCRYPTED_RAMKEY  0x3A5C3C5A /* bram */
-#define BOOTROM_ENCRYPTED_OBHDR   0xA35C7CA5 /* obfuscated key in boot hdr */
-#define BOOTROM_ENCRYPTED_NONE    0x00000000 /* anything but efuse, ramkey*/
-#define BOOTROM_MIN_SRC_OFFSET    0x000008C0
-#define BOOTROM_RESERVED_0        0x00000000 /* MUST be set to 0 */
-#define BOOTROM_RESERVED_1        0x00000000 /* MUST be set to 0 */
+#define BOOTROM_WIDTH_DETECT     0xAA995566
+#define BOOTROM_IMG_ID           "XNLX"
+#define BOOTROM_ENCRYPTED_EFUSE  0xA5C3C5A3
+#define BOOTROM_ENCRYPTED_OEFUSE 0xA5C3C5A7 /* obfuscated key in eFUSE */
+#define BOOTROM_ENCRYPTED_RAMKEY 0x3A5C3C5A /* bram */
+#define BOOTROM_ENCRYPTED_OBHDR  0xA35C7CA5 /* obfuscated key in boot hdr */
+#define BOOTROM_ENCRYPTED_NONE   0x00000000 /* anything but efuse, ramkey*/
+#define BOOTROM_MIN_SRC_OFFSET   0x000008C0
+#define BOOTROM_RESERVED_0       0x00000000 /* MUST be set to 0 */
+#define BOOTROM_RESERVED_1       0x00000000 /* MUST be set to 0 */
 
-#define BOOTROM_IMG_VERSION       0x01020000
+#define BOOTROM_IMG_VERSION 0x01020000
 
 #define BOOTROM_IMG_HDR_BOOT_SAME 0x0
 #define BOOTROM_IMG_HDR_BOOT_QSPI 0x1
@@ -241,28 +241,28 @@ typedef struct linux_image_header_t {
 #define BOOTROM_IMG_HDR_BOOT_SATA 0x8
 
 /* TODO find definitions for other CPUs */
-#define BOOTROM_FSBL_CPU_R5       0x001
-#define BOOTROM_FSBL_CPU_A53_64   0x800
+#define BOOTROM_FSBL_CPU_R5     0x001
+#define BOOTROM_FSBL_CPU_A53_64 0x800
 
 /* Other file specific files */
-#define FILE_MAGIC_ELF            0x464C457F
+#define FILE_MAGIC_ELF 0x464C457F
 
-#define FILE_MAGIC_XILINXBIT_0    0xf00f0900
-#define FILE_MAGIC_XILINXBIT_1    0xf00ff00f
+#define FILE_MAGIC_XILINXBIT_0 0xf00f0900
+#define FILE_MAGIC_XILINXBIT_1 0xf00ff00f
 
-#define FILE_MAGIC_LINUX          0x56190527
-#define FILE_MAGIC_DTB            0xedfe0dd0
+#define FILE_MAGIC_LINUX 0x56190527
+#define FILE_MAGIC_DTB   0xedfe0dd0
 
-#define FILE_XILINXBIT_SEC_START  13
-#define FILE_XILINXBIT_SEC_DATA   'e'
+#define FILE_XILINXBIT_SEC_START 13
+#define FILE_XILINXBIT_SEC_DATA  'e'
 
-#define FILE_LINUX_IMG_TYPE_UIM   2
-#define FILE_LINUX_IMG_TYPE_URD   3
-#define FILE_LINUX_IMG_TYPE_SCR   6
+#define FILE_LINUX_IMG_TYPE_UIM 2
+#define FILE_LINUX_IMG_TYPE_URD 3
+#define FILE_LINUX_IMG_TYPE_SCR 6
 
-#define BINARY_ATTR_LINUX         0x00
-#define BINARY_ATTR_RAMDISK       0x02
-#define BINARY_ATTR_GENERAL       0x01
+#define BINARY_ATTR_LINUX   0x00
+#define BINARY_ATTR_RAMDISK 0x02
+#define BINARY_ATTR_GENERAL 0x01
 
 typedef struct bootrom_offs_t {
   /* pointer to the image in memory */
@@ -284,48 +284,39 @@ typedef struct bootrom_offs_t {
 typedef struct bootrom_ops_t {
   /* Initialize offsets - image pointer should be
    * set before this one is called */
-  int (*init_offs)(uint32_t*, int, bootrom_offs_t*);
+  int (*init_offs)(uint32_t *, int, bootrom_offs_t *);
 
   /* Initialize the main bootrom header */
-  int (*init_header)(bootrom_hdr_t*, bootrom_offs_t*);
+  int (*init_header)(bootrom_hdr_t *, bootrom_offs_t *);
 
   /* Setup bootloader at the current offset */
-  int (*setup_fsbl_at_curr_off)(bootrom_hdr_t*,
-                                bootrom_offs_t*,
-                                uint32_t img_len);
+  int (*setup_fsbl_at_curr_off)(bootrom_hdr_t *, bootrom_offs_t *, uint32_t img_len);
 
   /* Prepare image header table */
-  int (*init_img_hdr_tab)(bootrom_img_hdr_tab_t*,
-                          bootrom_img_hdr_t*,
-                          bootrom_partition_hdr_t*,
-                          bootrom_offs_t*);
+  int (*init_img_hdr_tab)(bootrom_img_hdr_tab_t *,
+                          bootrom_img_hdr_t *,
+                          bootrom_partition_hdr_t *,
+                          bootrom_offs_t *);
 
   /* Partition header related callbacks */
-  int (*init_part_hdr_default)(bootrom_partition_hdr_t*,
-                               bif_node_t*);
-  int (*init_part_hdr_dtb)(bootrom_partition_hdr_t*,
-                           bif_node_t*);
-  int (*init_part_hdr_elf)(bootrom_partition_hdr_t*,
-                           bif_node_t*,
+  int (*init_part_hdr_default)(bootrom_partition_hdr_t *, bif_node_t *);
+  int (*init_part_hdr_dtb)(bootrom_partition_hdr_t *, bif_node_t *);
+  int (*init_part_hdr_elf)(bootrom_partition_hdr_t *,
+                           bif_node_t *,
                            uint32_t *size,
                            uint32_t load,
                            uint32_t entry,
                            uint8_t nbits);
-  int (*init_part_hdr_bitstream)(bootrom_partition_hdr_t*,
-                                 bif_node_t*);
-  int (*init_part_hdr_linux)(bootrom_partition_hdr_t*,
-                             bif_node_t*,
-                             linux_image_header_t*);
+  int (*init_part_hdr_bitstream)(bootrom_partition_hdr_t *, bif_node_t *);
+  int (*init_part_hdr_linux)(bootrom_partition_hdr_t *, bif_node_t *, linux_image_header_t *);
   /* The finish function is common for all partition types */
-  int (*finish_part_hdr)(bootrom_partition_hdr_t*,
-                         uint32_t *img_size,
-                         bootrom_offs_t*);
+  int (*finish_part_hdr)(bootrom_partition_hdr_t *, uint32_t *img_size, bootrom_offs_t *);
 
   /* Some archs require a null partition at the end */
   uint8_t append_null_part;
 } bootrom_ops_t;
 
-uint32_t estimate_boot_image_size(bif_cfg_t*);
-int create_boot_image(uint32_t*, bif_cfg_t*, bootrom_ops_t*, uint32_t*);
+uint32_t estimate_boot_image_size(bif_cfg_t *);
+int create_boot_image(uint32_t *, bif_cfg_t *, bootrom_ops_t *, uint32_t *);
 
 #endif /* BOOTROM_H */

--- a/src/common.c
+++ b/src/common.c
@@ -1,8 +1,8 @@
-#include <stdio.h>
+#include <stdarg.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdarg.h>
 
 #include <common.h>
 
@@ -25,7 +25,7 @@ uint32_t calc_checksum(uint32_t *start_addr, uint32_t *end_addr) {
   sum = 0;
   ptr = start_addr;
 
-  while(ptr <= end_addr) {
+  while (ptr <= end_addr) {
     sum += *ptr;
     ptr++;
   }
@@ -35,7 +35,7 @@ uint32_t calc_checksum(uint32_t *start_addr, uint32_t *end_addr) {
 
 /* Check if pfix is a postifx of string */
 int is_postfix(char *string, char *pfix) {
-  return strcmp(string+strlen(string)-strlen(pfix), pfix) == 0;
+  return strcmp(string + strlen(string) - strlen(pfix), pfix) == 0;
 }
 
 /* Check if a string is present on a list*/

--- a/src/common.h
+++ b/src/common.h
@@ -2,7 +2,7 @@
 #define MKBOOTIMAGE_COMMON_H
 
 int errorf(const char *fmt, ...);
-uint32_t calc_checksum(uint32_t*, uint32_t*);
+uint32_t calc_checksum(uint32_t *, uint32_t *);
 int is_postfix(char *, char *);
 int is_on_list(char **, char *);
 

--- a/src/exbootimage.c
+++ b/src/exbootimage.c
@@ -126,6 +126,7 @@ static char args_doc[] = "[--zynqmp|-u] "
                          "[--bitstream|-bDESIGN,PART-NAME] "
                          "<input_bit_file> <files_to_extract>";
 
+/* clang-format off */
 static struct argp_option argp_options[] = {
   {"zynqmp",    'u', 0, 0, "Expect files for ZynqMP (default is Zynq)", 0},
   {"extract",   'x', 0, 0, "Extract files embed in the image",          0},
@@ -139,7 +140,7 @@ static struct argp_option argp_options[] = {
    "DESIGN,PART-NAME", 0,
    "Reconstruct bitstream headers after extraction", 0
   },
-  { 0 }
+  {0},
 };
 
 static struct format hdr_fmt[] = {
@@ -154,7 +155,7 @@ static struct format hdr_fmt[] = {
   FORMAT("Total FSBL Length",       hdr_t, total_img_len,     dec),
   FORMAT("QSPI configuration Word", hdr_t, reserved_1,        word),
   FORMAT("Boot Header Checksum",    hdr_t, checksum,          word),
-  { 0 }
+  {0},
 };
 
 static struct format img_hdr_tab_fmt[] = {
@@ -163,13 +164,13 @@ static struct format img_hdr_tab_fmt[] = {
   FORMAT("Partition Header Offset",       img_hdr_tab_t, part_hdr_off,     word),
   FORMAT("Partition Image Header Offset", img_hdr_tab_t, part_img_hdr_off, word),
   FORMAT("Header Authentication Offset",  img_hdr_tab_t, auth_hdr_off,     word),
-  { 0 }
+  {0},
 };
 
 static struct format zynqmp_img_hdr_tab_fmt[] = {
   FORMAT("(ZynqMP) Boot Device", img_hdr_tab_t, boot_dev, word),
   FORMAT("(ZynqMP) Checksum",    img_hdr_tab_t, checksum, word),
-  { 0 }
+  {0},
 };
 
 static struct format img_hdr_fmt[] = {
@@ -178,7 +179,7 @@ static struct format img_hdr_fmt[] = {
   FORMAT("Partition Count (always 0)", img_hdr_t, part_count,   dec),
   FORMAT("Name Length (usually 1)",    img_hdr_t, name_len,     dec),
   FORMAT("Image Name",                 img_hdr_t, name,         name),
-  { 0 }
+  {0},
 };
 
 static struct format zynq_hdr_fmt[] = {
@@ -194,7 +195,7 @@ static struct format zynq_hdr_fmt[] = {
   FORMAT("Image Header Offset",     zynq_hdr_t, img_hdr_off,    word),
   FORMAT("Certificate Offset",      zynq_hdr_t, cert_off,       word),
   FORMAT("Checksum",                zynq_hdr_t, checksum,       word),
-  { 0 }
+  {0},
 };
 
 static struct format zynqmp_hdr_fmt[] = {
@@ -211,8 +212,9 @@ static struct format zynqmp_hdr_fmt[] = {
   FORMAT("Image Header Offset",     zynqmp_hdr_t, img_hdr_off,       word),
   FORMAT("Certificate Offset",      zynqmp_hdr_t, cert_off,          word),
   FORMAT("Checksum",                zynqmp_hdr_t, checksum,          word),
-  { 0 }
+  {0},
 };
+/* clang-format on */
 
 /* Print a word as a decimal*/
 int print_dec(FILE *f, void *base, int offset) {

--- a/src/file/bitstream.c
+++ b/src/file/bitstream.c
@@ -13,24 +13,25 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdint.h>
-#include <time.h>
 
 #include <bootrom.h>
 #include <common.h>
 #include <file/bitstream.h>
+#include <time.h>
 
 int bitstream_verify(FILE *bitfile) {
   uint32_t fhdr;
@@ -51,9 +52,7 @@ int bitstream_verify(FILE *bitfile) {
   return BOOTROM_SUCCESS;
 }
 
-int bitstream_write_header_part(FILE *bitfile,
-                              const uint8_t tag,
-                              const char *data) {
+int bitstream_write_header_part(FILE *bitfile, const uint8_t tag, const char *data) {
   uint16_t len = strlen(data) + 1;
   uint8_t n;
 
@@ -69,13 +68,21 @@ int bitstream_write_header_part(FILE *bitfile,
   return 0;
 }
 
-int bitstream_write_header(FILE *bitfile,
-                           uint32_t size,
-                           const char *design,
-                           const char *part) {
+int bitstream_write_header(FILE *bitfile, uint32_t size, const char *design, const char *part) {
   const uint8_t header[] = {
-    0x00, 0x09, 0x0f, 0xf0, 0x0f, 0xf0, 0x0f,
-    0xf0, 0x0f, 0xf0, 0x00, 0x00, 0x01,
+    0x00,
+    0x09,
+    0x0f,
+    0xf0,
+    0x0f,
+    0xf0,
+    0x0f,
+    0xf0,
+    0x0f,
+    0xf0,
+    0x00,
+    0x00,
+    0x01,
   };
 
   int i;
@@ -101,11 +108,11 @@ int bitstream_write_header(FILE *bitfile,
   bitstream_write_header_part(bitfile, 'b', part);
 
   /* Write the section 'c' */
-  strftime(stime, sizeof(stime)-1, "%Y/%m/%d", &ltime);
+  strftime(stime, sizeof(stime) - 1, "%Y/%m/%d", &ltime);
   bitstream_write_header_part(bitfile, 'c', stime);
 
   /* Write the section 'd' */
-  strftime(stime, sizeof(stime)-1, "%H:%M:%S", &ltime);
+  strftime(stime, sizeof(stime) - 1, "%H:%M:%S", &ltime);
   bitstream_write_header_part(bitfile, 'd', stime);
 
   /* Write the start of the section 'e' */
@@ -113,7 +120,7 @@ int bitstream_write_header(FILE *bitfile,
   fwrite(&n, sizeof(uint8_t), 1, bitfile);
 
   for (i = 3; i >= 0; i--) {
-    n = (size >> (i*8)) & 0xFF;
+    n = (size >> (i * 8)) & 0xFF;
     fwrite(&n, sizeof(uint8_t), 1, bitfile);
   }
 

--- a/src/file/bitstream.h
+++ b/src/file/bitstream.h
@@ -4,10 +4,7 @@
 /* Check if this really is a bitstream file */
 int bitstream_verify(FILE *bitfile);
 
-int bitstream_write_header(FILE       *bfile,
-                           uint32_t    size,
-                           const char *design,
-                           const char *part);
+int bitstream_write_header(FILE *bfile, uint32_t size, const char *design, const char *part);
 
 /* Returns the appended bitstream size via the last argument.
  * The regular return value is the error code. */

--- a/src/file/elf.c
+++ b/src/file/elf.c
@@ -13,34 +13,32 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
 #include <stdint.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <gelf.h>
+#include <stdio.h>
 
 #include <bootrom.h>
+#include <fcntl.h>
 #include <file/elf.h>
+#include <gelf.h>
+#include <unistd.h>
 
 static int elf_is_loadable_section(const GElf_Shdr *elf_shdr) {
-  return elf_shdr->sh_type != SHT_NOBITS &&
-         (elf_shdr->sh_flags & SHF_ALLOC) &&
+  return elf_shdr->sh_type != SHT_NOBITS && (elf_shdr->sh_flags & SHF_ALLOC) &&
          elf_shdr->sh_size != 0;
 }
 
-static int elf_get_startaddr_endaddr(Elf *elf,
-                                     uint32_t *start_addr,
-                                     uint32_t *end_addr) {
+static int elf_get_startaddr_endaddr(Elf *elf, uint32_t *start_addr, uint32_t *end_addr) {
   Elf_Scn *elf_scn = NULL;
   GElf_Shdr elf_shdr;
   *start_addr = -1;
@@ -63,9 +61,7 @@ static int elf_get_startaddr_endaddr(Elf *elf,
   return BOOTROM_SUCCESS;
 }
 
-static int elf_create_image(Elf *elf,
-                            uint32_t start_addr,
-                            uint8_t *out_buf) {
+static int elf_create_image(Elf *elf, uint32_t start_addr, uint8_t *out_buf) {
   Elf_Scn *elf_scn = NULL;
   Elf_Data *elf_data;
   GElf_Shdr elf_shdr;
@@ -73,7 +69,6 @@ static int elf_create_image(Elf *elf,
   while ((elf_scn = elf_nextscn(elf, elf_scn)) != NULL) {
     if (gelf_getshdr(elf_scn, &elf_shdr) != &elf_shdr)
       return -BOOTROM_ERROR_ELF;
-
 
     if (!elf_is_loadable_section(&elf_shdr))
       continue;
@@ -85,7 +80,8 @@ static int elf_create_image(Elf *elf,
         return -BOOTROM_ERROR_ELF;
 
       memcpy(out_buf + elf_shdr.sh_addr + elf_data->d_off - start_addr,
-             elf_data->d_buf, elf_data->d_size);
+             elf_data->d_buf,
+             elf_data->d_size);
     }
   }
 

--- a/src/mkbootimage.c
+++ b/src/mkbootimage.c
@@ -43,7 +43,7 @@ static char args_doc[] = "[--parse-only|-p] [--zynqmp|-u] <input_bif_file> <outp
 static struct argp_option argp_options[] = {
   {"zynqmp",     'u', 0, 0, "Generate files for ZyqnMP (default is Zynq)",       0},
   {"parse-only", 'p', 0, 0, "Analyze BIF grammar, but don't generate any files", 0},
-  { 0 }
+  { 0 },
 };
 
 /* Prapare struct for holding parsed arguments */

--- a/src/mkbootimage.c
+++ b/src/mkbootimage.c
@@ -13,27 +13,27 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <argp.h>
-
-#include <bif.h>
-#include <bootrom.h>
-#include <common.h>
+#include <stdlib.h>
 
 #include <arch/zynq.h>
 #include <arch/zynqmp.h>
+#include <argp.h>
+#include <bif.h>
+#include <bootrom.h>
+#include <common.h>
 
 /* Prepare global variables for arg parser */
 const char *argp_program_version = MKBOOTIMAGE_VER;
@@ -41,9 +41,9 @@ static char doc[] = "Generate bootloader images for Xilinx Zynq based platforms.
 static char args_doc[] = "[--parse-only|-p] [--zynqmp|-u] <input_bif_file> <output_bin_file>";
 
 static struct argp_option argp_options[] = {
-  {"zynqmp",     'u', 0, 0, "Generate files for ZyqnMP (default is Zynq)",       0},
+  {"zynqmp", 'u', 0, 0, "Generate files for ZyqnMP (default is Zynq)", 0},
   {"parse-only", 'p', 0, 0, "Analyze BIF grammar, but don't generate any files", 0},
-  { 0 },
+  {0},
 };
 
 /* Prapare struct for holding parsed arguments */
@@ -66,7 +66,7 @@ static error_t argp_parser(int key, char *arg, struct argp_state *state) {
     arguments->parse_only = 0xFF;
     break;
   case ARGP_KEY_ARG:
-    switch(state->arg_num) {
+    switch (state->arg_num) {
     case 0:
       arguments->bif_filename = arg;
       break;
@@ -90,7 +90,7 @@ static error_t argp_parser(int key, char *arg, struct argp_state *state) {
 }
 
 /* Finally initialize argp struct */
-static struct argp argp = {argp_options, argp_parser, args_doc, doc, 0, 0, 0 };
+static struct argp argp = {argp_options, argp_parser, args_doc, doc, 0, 0, 0};
 
 /* Declare the main function */
 int main(int argc, char *argv[]) {
@@ -169,7 +169,7 @@ int main(int argc, char *argv[]) {
 
   ofile = fopen(arguments.bin_filename, "wb");
 
-  if (ofile == NULL ) {
+  if (ofile == NULL) {
     errorf("could not open output file: %s\n", arguments.bin_filename);
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
A uniform coding style for the whole project has been chosen. It is enforced with usage of `clang-format` (version 12). The parts of the code that didn't match the style have been adjusted, and format checks have been added into repository's Actions.
