### PR TITLE
Unify error codes

### DIFF
--- a/src/arch/common.c
+++ b/src/arch/common.c
@@ -7,7 +7,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
-int bootrom_init_header(bootrom_hdr_t *hdr) {
+error bootrom_init_header(bootrom_hdr_t *hdr) {
   unsigned int i = 0;
   for (i = 0; i < sizeof(hdr->interrupt_table) / sizeof(hdr->interrupt_table[0]); i++) {
     hdr->interrupt_table[i] = BOOTROM_INT_TABLE_DEFAULT;
@@ -24,7 +24,7 @@ int bootrom_init_header(bootrom_hdr_t *hdr) {
   hdr->total_img_len = 0x0; /* Will be filled elsewhere */
   hdr->reserved_1 = BOOTROM_RESERVED_1_RL;
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
 void bootrom_calc_hdr_checksum(bootrom_hdr_t *hdr) {
@@ -33,7 +33,7 @@ void bootrom_calc_hdr_checksum(bootrom_hdr_t *hdr) {
   hdr->checksum = calc_checksum(&(hdr->width_detect), &(hdr->checksum) - 1);
 }
 
-int bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab, bootrom_offs_t *offs) {
+error bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab, bootrom_offs_t *offs) {
   /* Prepare image header table */
   img_hdr_tab->version = BOOTROM_IMG_VERSION;
   img_hdr_tab->part_hdr_off = 0x0;     /* filled below */
@@ -46,5 +46,5 @@ int bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab, bootrom_offs_t 
   offs->hoff = offs->poff;
   offs->poff += sizeof(*img_hdr_tab) / sizeof(uint32_t);
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }

--- a/src/arch/common.h
+++ b/src/arch/common.h
@@ -3,8 +3,8 @@
 
 #include <bootrom.h>
 
-int bootrom_init_header(bootrom_hdr_t*);
+error bootrom_init_header(bootrom_hdr_t*);
 void bootrom_calc_hdr_checksum(bootrom_hdr_t*);
-int bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t*, bootrom_offs_t*);
+error bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t*, bootrom_offs_t*);
 
 #endif

--- a/src/arch/zynqmp.c
+++ b/src/arch/zynqmp.c
@@ -15,7 +15,7 @@
 
 #define BOOTROM_ZYNQMP_OFFSET_AFTER_HEADERS 0x40
 
-int zynqmp_bootrom_init_offs(uint32_t *img_ptr, int hdr_count, bootrom_offs_t *offs) {
+error zynqmp_bootrom_init_offs(uint32_t *img_ptr, int hdr_count, bootrom_offs_t *offs) {
   /* Copy the image pointer */
   offs->img_ptr = img_ptr;
 
@@ -31,17 +31,16 @@ int zynqmp_bootrom_init_offs(uint32_t *img_ptr, int hdr_count, bootrom_offs_t *o
   offs->poff = (offs->img_hdr_off) / sizeof(uint32_t) + img_ptr;
   offs->coff = (offs->bins_off) / sizeof(uint32_t) + img_ptr;
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
-int zynqmp_bootrom_init_header(bootrom_hdr_t *hdr, bootrom_offs_t *offs) {
+error zynqmp_bootrom_init_header(bootrom_hdr_t *hdr, bootrom_offs_t *offs) {
   int i;
-  int ret;
+  error err;
 
   /* Call the common init */
-  ret = bootrom_init_header(hdr);
-  if (ret != BOOTROM_SUCCESS)
-    return ret;
+  if ((err = bootrom_init_header(hdr)))
+    return err;
 
   hdr->fsbl_execution_addr = BOOTROM_FSBL_EXEC_ADDR;
 
@@ -70,12 +69,12 @@ int zynqmp_bootrom_init_header(bootrom_hdr_t *hdr, bootrom_offs_t *offs) {
   /* Calculate the checksum */
   bootrom_calc_hdr_checksum(hdr);
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
-int zynqmp_bootrom_setup_fsbl_at_curr_off(bootrom_hdr_t *hdr,
-                                          bootrom_offs_t *offs,
-                                          uint32_t img_len) {
+error zynqmp_bootrom_setup_fsbl_at_curr_off(bootrom_hdr_t *hdr,
+                                            bootrom_offs_t *offs,
+                                            uint32_t img_len) {
   /* Update the header to point at the bootloader */
   hdr->src_offset = (offs->coff - offs->img_ptr) * sizeof(uint32_t);
 
@@ -93,13 +92,13 @@ int zynqmp_bootrom_setup_fsbl_at_curr_off(bootrom_hdr_t *hdr,
   /* Recalculate the checksum */
   bootrom_calc_hdr_checksum(hdr);
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
-int zynqmp_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
-                                    bootrom_img_hdr_t *img_hdr,
-                                    bootrom_partition_hdr_t *ihdr,
-                                    bootrom_offs_t *offs) {
+error zynqmp_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
+                                      bootrom_img_hdr_t *img_hdr,
+                                      bootrom_partition_hdr_t *ihdr,
+                                      bootrom_offs_t *offs) {
   unsigned int i;
   uint32_t img_hdr_size = 0;
 
@@ -160,7 +159,7 @@ int zynqmp_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
   /* Recalculate the checksum */
   img_hdr_tab->checksum = calc_checksum(&img_hdr_tab->version, &(img_hdr_tab->checksum) - 1);
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
 uint32_t zynqmp_calc_part_hdr_attr(bif_node_t *node) {
@@ -222,7 +221,7 @@ uint32_t zynqmp_calc_part_hdr_attr(bif_node_t *node) {
   return attr;
 }
 
-int zynqmp_init_part_hdr_default(bootrom_partition_hdr_t *ihdr, bif_node_t *node) {
+error zynqmp_init_part_hdr_default(bootrom_partition_hdr_t *ihdr, bif_node_t *node) {
   /* Retrieve the header */
   bootrom_partition_hdr_zynqmp_t *hdr;
   hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
@@ -232,15 +231,15 @@ int zynqmp_init_part_hdr_default(bootrom_partition_hdr_t *ihdr, bif_node_t *node
 
   hdr->dest_load_addr_lo = node->load;
   hdr->dest_exec_addr_hi = 0x0;
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
-int zynqmp_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
-                             bif_node_t *node,
-                             uint32_t *size,
-                             uint32_t load,
-                             uint32_t entry,
-                             uint8_t nbits) {
+error zynqmp_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
+                               bif_node_t *node,
+                               uint32_t *size,
+                               uint32_t load,
+                               uint32_t entry,
+                               uint8_t nbits) {
   /* Retrieve the header */
   bootrom_partition_hdr_zynqmp_t *hdr;
   hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
@@ -271,10 +270,10 @@ int zynqmp_init_part_hdr_elf(bootrom_partition_hdr_t *ihdr,
     hdr->attributes |= BOOTROM_PART_ATTR_A5X_EXEC_S_64;
   }
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
-int zynqmp_init_part_hdr_bitstream(bootrom_partition_hdr_t *ihdr, bif_node_t *node) {
+error zynqmp_init_part_hdr_bitstream(bootrom_partition_hdr_t *ihdr, bif_node_t *node) {
   (void) node;
   /* Retrieve the header */
   bootrom_partition_hdr_zynqmp_t *hdr;
@@ -288,12 +287,12 @@ int zynqmp_init_part_hdr_bitstream(bootrom_partition_hdr_t *ihdr, bif_node_t *no
   hdr->dest_load_addr_hi = 0x0;
   hdr->dest_exec_addr_lo = 0x0;
   hdr->dest_exec_addr_hi = 0x0;
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
-int zynqmp_init_part_hdr_linux(bootrom_partition_hdr_t *ihdr,
-                               bif_node_t *node,
-                               linux_image_header_t *img) {
+error zynqmp_init_part_hdr_linux(bootrom_partition_hdr_t *ihdr,
+                                 bif_node_t *node,
+                                 linux_image_header_t *img) {
   bootrom_partition_hdr_zynqmp_t *hdr;
   hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
 
@@ -316,12 +315,12 @@ int zynqmp_init_part_hdr_linux(bootrom_partition_hdr_t *ihdr,
   /* No load/execution address */
   hdr->dest_load_addr_lo = node->load;
   hdr->dest_exec_addr_lo = 0x0;
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
-int zynqmp_finish_part_hdr(bootrom_partition_hdr_t *ihdr,
-                           uint32_t *img_size,
-                           bootrom_offs_t *offs) {
+error zynqmp_finish_part_hdr(bootrom_partition_hdr_t *ihdr,
+                             uint32_t *img_size,
+                             bootrom_offs_t *offs) {
   /* Retrieve the header */
   bootrom_partition_hdr_zynqmp_t *hdr;
   hdr = (bootrom_partition_hdr_zynqmp_t *) ihdr;
@@ -351,7 +350,7 @@ int zynqmp_finish_part_hdr(bootrom_partition_hdr_t *ihdr,
     (*img_size)++;
   }
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
 /* Define ops */

--- a/src/bif.h
+++ b/src/bif.h
@@ -5,15 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <common.h>
 #include <linux/limits.h>
-
-#define BIF_SUCCESS                0
-#define BIF_ERROR_NOFILE           1
-#define BIF_ERROR_PARSER           2
-#define BIF_ERROR_UNSUPPORTED_ATTR 3
-#define BIF_ERROR_UNINITIALIZED    4
-#define BIF_ERROR_UNSUPPORTED_VAL  5
-#define BIF_ERROR_LEXER            6
 
 #define BIF_ARCH_ZYNQ   (1 << 0)
 #define BIF_ARCH_ZYNQMP (1 << 1)
@@ -103,12 +96,13 @@ typedef struct bif_cfg_t {
   bif_node_t *nodes;
 } bif_cfg_t;
 
-int init_bif_cfg(bif_cfg_t *cfg);
-int deinit_bif_cfg(bif_cfg_t *cfg);
+error init_bif_cfg(bif_cfg_t *cfg);
+error deinit_bif_cfg(bif_cfg_t *cfg);
 
-int bif_cfg_add_node(bif_cfg_t *cfg, bif_node_t *node);
-int bif_node_set_attr(lexer_t *lex, bif_cfg_t *cfg, bif_node_t *node, char *attr_name, char *value);
+error bif_cfg_add_node(bif_cfg_t *cfg, bif_node_t *node);
+error bif_node_set_attr(
+  lexer_t *lex, bif_cfg_t *cfg, bif_node_t *node, char *attr_name, char *value);
 
-int bif_parse(const char *fname, bif_cfg_t *cfg);
+error bif_parse(const char *fname, bif_cfg_t *cfg);
 
 #endif /* BIF_PARSER_H */

--- a/src/bootrom.h
+++ b/src/bootrom.h
@@ -4,15 +4,6 @@
 #include <bif.h>
 #include <gelf.h>
 
-#define BOOTROM_SUCCESS           0
-#define BOOTROM_ERROR_NOFILE      1
-#define BOOTROM_ERROR_BITSTREAM   2
-#define BOOTROM_ERROR_ELF         3
-#define BOOTROM_ERROR_SEC_OVERLAP 4
-#define BOOTROM_ERROR_UNSUPPORTED 5
-#define BOOTROM_ERROR_NOMEM       6
-#define BOOTROM_ERROR_WADDR       7
-
 /* BootROM Header based on ug585 and ug1085 */
 typedef struct bootrom_hdr_t {
   uint32_t interrupt_table[8];
@@ -284,39 +275,39 @@ typedef struct bootrom_offs_t {
 typedef struct bootrom_ops_t {
   /* Initialize offsets - image pointer should be
    * set before this one is called */
-  int (*init_offs)(uint32_t *, int, bootrom_offs_t *);
+  error (*init_offs)(uint32_t *, int, bootrom_offs_t *);
 
   /* Initialize the main bootrom header */
-  int (*init_header)(bootrom_hdr_t *, bootrom_offs_t *);
+  error (*init_header)(bootrom_hdr_t *, bootrom_offs_t *);
 
   /* Setup bootloader at the current offset */
-  int (*setup_fsbl_at_curr_off)(bootrom_hdr_t *, bootrom_offs_t *, uint32_t img_len);
+  error (*setup_fsbl_at_curr_off)(bootrom_hdr_t *, bootrom_offs_t *, uint32_t img_len);
 
   /* Prepare image header table */
-  int (*init_img_hdr_tab)(bootrom_img_hdr_tab_t *,
-                          bootrom_img_hdr_t *,
-                          bootrom_partition_hdr_t *,
-                          bootrom_offs_t *);
+  error (*init_img_hdr_tab)(bootrom_img_hdr_tab_t *,
+                            bootrom_img_hdr_t *,
+                            bootrom_partition_hdr_t *,
+                            bootrom_offs_t *);
 
   /* Partition header related callbacks */
-  int (*init_part_hdr_default)(bootrom_partition_hdr_t *, bif_node_t *);
-  int (*init_part_hdr_dtb)(bootrom_partition_hdr_t *, bif_node_t *);
-  int (*init_part_hdr_elf)(bootrom_partition_hdr_t *,
-                           bif_node_t *,
-                           uint32_t *size,
-                           uint32_t load,
-                           uint32_t entry,
-                           uint8_t nbits);
-  int (*init_part_hdr_bitstream)(bootrom_partition_hdr_t *, bif_node_t *);
-  int (*init_part_hdr_linux)(bootrom_partition_hdr_t *, bif_node_t *, linux_image_header_t *);
+  error (*init_part_hdr_default)(bootrom_partition_hdr_t *, bif_node_t *);
+  error (*init_part_hdr_dtb)(bootrom_partition_hdr_t *, bif_node_t *);
+  error (*init_part_hdr_elf)(bootrom_partition_hdr_t *,
+                             bif_node_t *,
+                             uint32_t *size,
+                             uint32_t load,
+                             uint32_t entry,
+                             uint8_t nbits);
+  error (*init_part_hdr_bitstream)(bootrom_partition_hdr_t *, bif_node_t *);
+  error (*init_part_hdr_linux)(bootrom_partition_hdr_t *, bif_node_t *, linux_image_header_t *);
   /* The finish function is common for all partition types */
-  int (*finish_part_hdr)(bootrom_partition_hdr_t *, uint32_t *img_size, bootrom_offs_t *);
+  error (*finish_part_hdr)(bootrom_partition_hdr_t *, uint32_t *img_size, bootrom_offs_t *);
 
   /* Some archs require a null partition at the end */
   uint8_t append_null_part;
 } bootrom_ops_t;
 
 uint32_t estimate_boot_image_size(bif_cfg_t *);
-int create_boot_image(uint32_t *, bif_cfg_t *, bootrom_ops_t *, uint32_t *);
+error create_boot_image(uint32_t *, bif_cfg_t *, bootrom_ops_t *, uint32_t *);
 
 #endif /* BOOTROM_H */

--- a/src/common.h
+++ b/src/common.h
@@ -1,6 +1,39 @@
 #ifndef MKBOOTIMAGE_COMMON_H
 #define MKBOOTIMAGE_COMMON_H
 
+typedef enum error
+{
+  /* The job was ended sucessfully */
+  SUCCESS = 0,
+
+  /* Common error codes */
+  ERROR_NOMEM = 1,
+  ERROR_CANT_READ,
+  ERROR_CANT_WRITE,
+  ERROR_ITERATION_END,
+
+  /* BIF parser specific errors */
+  ERROR_BIF_NOFILE,
+  ERROR_BIF_PARSER,
+  ERROR_BIF_UNSUPPORTED_ATTR,
+  ERROR_BIF_UNINITIALIZED,
+  ERROR_BIF_UNSUPPORTED_VAL,
+  ERROR_BIF_LEXER,
+
+  /* Bootrom compiler specific errors */
+  ERROR_BOOTROM_NOFILE,
+  ERROR_BOOTROM_BITSTREAM,
+  ERROR_BOOTROM_ELF,
+  ERROR_BOOTROM_SEC_OVERLAP,
+  ERROR_BOOTROM_UNSUPPORTED,
+  ERROR_BOOTROM_NOMEM,
+
+  /* Bootrom parser specific errors */
+  ERROR_BIN_FILE_EXISTS,
+  ERROR_BIN_NOFILE,
+  ERROR_BIN_WADDR,
+} error;
+
 int errorf(const char *fmt, ...);
 uint32_t calc_checksum(uint32_t *, uint32_t *);
 int is_postfix(char *, char *);

--- a/src/file/bitstream.c
+++ b/src/file/bitstream.c
@@ -33,7 +33,7 @@
 #include <file/bitstream.h>
 #include <time.h>
 
-int bitstream_verify(FILE *bitfile) {
+error bitstream_verify(FILE *bitfile) {
   uint32_t fhdr;
 
   /* Seek to the start of the file */
@@ -41,15 +41,15 @@ int bitstream_verify(FILE *bitfile) {
 
   fread(&fhdr, 1, sizeof(fhdr), bitfile);
   if (fhdr != FILE_MAGIC_XILINXBIT_0)
-    return -BOOTROM_ERROR_BITSTREAM;
+    return ERROR_BOOTROM_BITSTREAM;
 
   /* Xilinx header is 64b, check the other half */
   fread(&fhdr, 1, sizeof(fhdr), bitfile);
   if (fhdr != FILE_MAGIC_XILINXBIT_1)
-    return -BOOTROM_ERROR_BITSTREAM;
+    return ERROR_BOOTROM_BITSTREAM;
 
   /* Both halves match */
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
 int bitstream_write_header_part(FILE *bitfile, const uint8_t tag, const char *data) {
@@ -127,7 +127,7 @@ int bitstream_write_header(FILE *bitfile, uint32_t size, const char *design, con
   return 0;
 }
 
-int bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size) {
+error bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size) {
   uint32_t *dest = addr;
   uint32_t chunk, rchunk;
   uint8_t section_size;
@@ -142,7 +142,7 @@ int bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size) {
     if (section_hdr[1] != 0x1 && section_hdr[1] != 0x0) {
       fclose(bitfile);
       errorf("bitstream file seems to have mismatched sections.\n");
-      return -BOOTROM_ERROR_BITSTREAM;
+      return ERROR_BOOTROM_BITSTREAM;
     }
 
     if (section_hdr[0] == FILE_XILINXBIT_SEC_DATA)
@@ -165,5 +165,5 @@ int bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size) {
     dest++;
   }
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }

--- a/src/file/bitstream.h
+++ b/src/file/bitstream.h
@@ -2,12 +2,12 @@
 #define BITSTREAM_H
 
 /* Check if this really is a bitstream file */
-int bitstream_verify(FILE *bitfile);
+error bitstream_verify(FILE *bitfile);
 
 int bitstream_write_header(FILE *bfile, uint32_t size, const char *design, const char *part);
 
 /* Returns the appended bitstream size via the last argument.
  * The regular return value is the error code. */
-int bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size);
+error bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size);
 
 #endif

--- a/src/file/elf.c
+++ b/src/file/elf.c
@@ -38,7 +38,7 @@ static int elf_is_loadable_section(const GElf_Shdr *elf_shdr) {
          elf_shdr->sh_size != 0;
 }
 
-static int elf_get_startaddr_endaddr(Elf *elf, uint32_t *start_addr, uint32_t *end_addr) {
+static error elf_get_startaddr_endaddr(Elf *elf, uint32_t *start_addr, uint32_t *end_addr) {
   Elf_Scn *elf_scn = NULL;
   GElf_Shdr elf_shdr;
   *start_addr = -1;
@@ -46,7 +46,7 @@ static int elf_get_startaddr_endaddr(Elf *elf, uint32_t *start_addr, uint32_t *e
 
   while ((elf_scn = elf_nextscn(elf, elf_scn)) != NULL) {
     if (gelf_getshdr(elf_scn, &elf_shdr) != &elf_shdr)
-      return -BOOTROM_ERROR_ELF;
+      return ERROR_BOOTROM_ELF;
 
     if (!elf_is_loadable_section(&elf_shdr))
       continue;
@@ -58,17 +58,17 @@ static int elf_get_startaddr_endaddr(Elf *elf, uint32_t *start_addr, uint32_t *e
       *end_addr = elf_shdr.sh_addr + elf_shdr.sh_size;
   }
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
-static int elf_create_image(Elf *elf, uint32_t start_addr, uint8_t *out_buf) {
+static error elf_create_image(Elf *elf, uint32_t start_addr, uint8_t *out_buf) {
   Elf_Scn *elf_scn = NULL;
   Elf_Data *elf_data;
   GElf_Shdr elf_shdr;
 
   while ((elf_scn = elf_nextscn(elf, elf_scn)) != NULL) {
     if (gelf_getshdr(elf_scn, &elf_shdr) != &elf_shdr)
-      return -BOOTROM_ERROR_ELF;
+      return ERROR_BOOTROM_ELF;
 
     if (!elf_is_loadable_section(&elf_shdr))
       continue;
@@ -77,7 +77,7 @@ static int elf_create_image(Elf *elf, uint32_t start_addr, uint8_t *out_buf) {
 
     while ((elf_data = elf_rawdata(elf_scn, elf_data)) != NULL) {
       if (!elf_data->d_buf)
-        return -BOOTROM_ERROR_ELF;
+        return ERROR_BOOTROM_ELF;
 
       memcpy(out_buf + elf_shdr.sh_addr + elf_data->d_off - start_addr,
              elf_data->d_buf,
@@ -85,16 +85,17 @@ static int elf_create_image(Elf *elf, uint32_t start_addr, uint8_t *out_buf) {
     }
   }
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }
 
-int elf_append(void *addr,
-               const char *fname,
-               uint32_t img_max_size,
-               uint32_t *img_size,
-               uint8_t *elf_nbits,
-               uint32_t *elf_load,
-               uint32_t *elf_entry) {
+error elf_append(void *addr,
+                 const char *fname,
+                 uint32_t img_max_size,
+                 uint32_t *img_size,
+                 uint8_t *elf_nbits,
+                 uint32_t *elf_load,
+                 uint32_t *elf_entry) {
+  error err;
   int fd_elf;
   Elf *elf;
   GElf_Ehdr elf_ehdr;
@@ -103,49 +104,49 @@ int elf_append(void *addr,
 
   /* Init elf library */
   if (elf_version(EV_CURRENT) == EV_NONE)
-    return -BOOTROM_ERROR_ELF;
+    return ERROR_BOOTROM_ELF;
 
   /* Open file descriptor used by elf library */
   if ((fd_elf = open(fname, O_RDONLY, 0)) < 0)
-    return -BOOTROM_ERROR_ELF;
+    return ERROR_BOOTROM_ELF;
 
   /* Init elf */
   if ((elf = elf_begin(fd_elf, ELF_C_READ, NULL)) == NULL) {
     close(fd_elf);
-    return -BOOTROM_ERROR_ELF;
+    return ERROR_BOOTROM_ELF;
   }
 
   /* Make sure it is an elf (despite magic byte check) */
   if (elf_kind(elf) != ELF_K_ELF) {
     elf_end(elf);
     close(fd_elf);
-    return -BOOTROM_ERROR_ELF;
+    return ERROR_BOOTROM_ELF;
   }
 
-  if (elf_get_startaddr_endaddr(elf, &start_addr, &end_addr) != BOOTROM_SUCCESS) {
+  if ((err = elf_get_startaddr_endaddr(elf, &start_addr, &end_addr))) {
     elf_end(elf);
     close(fd_elf);
-    return -BOOTROM_ERROR_ELF;
+    return err;
   }
 
   if (end_addr - start_addr > img_max_size) {
     elf_end(elf);
     close(fd_elf);
-    return -BOOTROM_ERROR_ELF;
+    return ERROR_BOOTROM_ELF;
   }
 
   memset(addr, 0, end_addr - start_addr);
 
-  if (elf_create_image(elf, start_addr, addr) != BOOTROM_SUCCESS) {
+  if ((err = elf_create_image(elf, start_addr, addr))) {
     elf_end(elf);
     close(fd_elf);
-    return -BOOTROM_ERROR_ELF;
+    return err;
   }
 
   if (gelf_getehdr(elf, &elf_ehdr) != &elf_ehdr) {
     elf_end(elf);
     close(fd_elf);
-    return -BOOTROM_ERROR_ELF;
+    return ERROR_BOOTROM_ELF;
   }
 
   *elf_load = start_addr;
@@ -156,5 +157,5 @@ int elf_append(void *addr,
   elf_end(elf);
   close(fd_elf);
 
-  return BOOTROM_SUCCESS;
+  return SUCCESS;
 }

--- a/src/file/elf.h
+++ b/src/file/elf.h
@@ -3,12 +3,12 @@
 
 /* Returns the appended file size and the elf header info via arguments.
  * The regular return value is the error code. */
-int elf_append(void *addr,
-               const char *fname,
-               uint32_t img_max_size,
-               uint32_t *img_size,
-               uint8_t *elf_nbits,
-               uint32_t *elf_load,
-               uint32_t *elf_entry);
+error elf_append(void *addr,
+                 const char *fname,
+                 uint32_t img_max_size,
+                 uint32_t *img_size,
+                 uint8_t *elf_nbits,
+                 uint32_t *elf_load,
+                 uint32_t *elf_entry);
 
 #endif


### PR DESCRIPTION
All error codes have been defined in `src/common.h` and are used by the whole project. The codes are values of the `error` type and so all routines that can fail return that type now.

Since errors of different types always have different codes as well, they can be used as exit status.
