### PR TITLE
Simplify code and use more precise types

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,4 +168,3 @@ the boot image name:
 ```
 ./exbootimage -x boot.bin fpga.bit rootfs.img
 ```
-

--- a/src/arch/common.c
+++ b/src/arch/common.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdio.h>
 
 #include <arch/common.h>

--- a/src/arch/zynq.c
+++ b/src/arch/zynq.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/arch/zynqmp.c
+++ b/src/arch/zynqmp.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/arch/zynqmp.c
+++ b/src/arch/zynqmp.c
@@ -164,59 +164,10 @@ error zynqmp_bootrom_init_img_hdr_tab(bootrom_img_hdr_tab_t *img_hdr_tab,
 
 uint32_t zynqmp_calc_part_hdr_attr(bif_node_t *node) {
   uint32_t attr = 0;
-
-  if (node->partition_owner == OWNER_FSBL)
-    attr |= BOOTROM_PART_ATTR_OWNER_FSBL;
-  else if (node->partition_owner == OWNER_UBOOT)
-    attr |= BOOTROM_PART_ATTR_OWNER_UBOOT;
-
-  if (node->destination_device == DST_DEV_PS)
-    attr |= BOOTROM_PART_ATTR_DEST_DEV_PS;
-  else if (node->destination_device == DST_DEV_PL)
-    attr |= BOOTROM_PART_ATTR_DEST_DEV_PL;
-
-  switch (node->destination_cpu) {
-  case DST_CPU_A53_0:
-    attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_0;
-    break;
-  case DST_CPU_A53_1:
-    attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_1;
-    break;
-  case DST_CPU_A53_2:
-    attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_2;
-    break;
-  case DST_CPU_A53_3:
-    attr |= BOOTROM_PART_ATTR_DEST_CPU_A53_3;
-    break;
-  case DST_CPU_R5_0:
-    attr |= BOOTROM_PART_ATTR_DEST_CPU_R5_0;
-    break;
-  case DST_CPU_R5_1:
-    attr |= BOOTROM_PART_ATTR_DEST_CPU_R5_1;
-    break;
-  case DST_CPU_R5_LOCKSTEP:
-    attr |= BOOTROM_PART_ATTR_DEST_CPU_R5_L;
-    break;
-  default:
-    break;
-  }
-
-  switch (node->exception_level) {
-  case EL_0:
-    attr |= BOOTROM_PART_ATTR_EXC_LVL_EL0;
-    break;
-  case EL_1:
-    attr |= BOOTROM_PART_ATTR_EXC_LVL_EL1;
-    break;
-  case EL_2:
-    attr |= BOOTROM_PART_ATTR_EXC_LVL_EL2;
-    break;
-  case EL_3:
-    attr |= BOOTROM_PART_ATTR_EXC_LVL_EL3;
-    break;
-  default:
-    break;
-  }
+  attr |= node->partition_owner;
+  attr |= node->destination_device;
+  attr |= node->destination_cpu;
+  attr |= node->exception_level;
 
   return attr;
 }

--- a/src/bif.c
+++ b/src/bif.c
@@ -461,7 +461,7 @@ error bif_node_set_attr(
       return ERROR_BIF_PARSER;
     }
     mask = map_name_to_mask(bootrom_part_attr_owner_names, value);
-    if (mask == 0xffffffff) {
+    if (mask == NOMASK) {
       perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
       return ERROR_BIF_UNSUPPORTED_VAL;
     }
@@ -489,7 +489,7 @@ error bif_node_set_attr(
         return ERROR_BIF_PARSER;
       }
       mask = map_name_to_mask(bootrom_part_attr_dest_dev_names, value);
-      if (mask == 0xffffffff) {
+      if (mask == NOMASK) {
         perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
         return ERROR_BIF_UNSUPPORTED_VAL;
       }
@@ -503,7 +503,7 @@ error bif_node_set_attr(
         return ERROR_BIF_PARSER;
       }
       mask = map_name_to_mask(bootrom_part_attr_dest_cpu_names, value);
-      if (mask == 0xffffffff) {
+      if (mask == NOMASK) {
         perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
         return ERROR_BIF_UNSUPPORTED_VAL;
       }
@@ -517,7 +517,7 @@ error bif_node_set_attr(
         return ERROR_BIF_PARSER;
       }
       mask = map_name_to_mask(bootrom_part_attr_exc_lvl_names, value);
-      if (mask == 0xffffffff) {
+      if (mask == NOMASK) {
         perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
         return ERROR_BIF_UNSUPPORTED_VAL;
       }

--- a/src/bif.c
+++ b/src/bif.c
@@ -425,6 +425,7 @@ error bif_parse(const char *fname, bif_cfg_t *cfg) {
 
 error bif_node_set_attr(
   lexer_t *lex, bif_cfg_t *cfg, bif_node_t *node, char *attr_name, char *value) {
+  uint32_t mask;
   /* TODO: parser errors on wrong scans */
 
   if (strcmp(attr_name, "bootloader") == 0) {
@@ -461,11 +462,8 @@ error bif_node_set_attr(
       perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
       return ERROR_BIF_PARSER;
     }
-    if (strcmp(value, "fsbl") == 0)
-      node->partition_owner = BOOTROM_PART_ATTR_OWNER_FSBL;
-    else if (strcmp(value, "uboot") == 0)
-      node->partition_owner = BOOTROM_PART_ATTR_OWNER_UBOOT;
-    else {
+    mask = map_name_to_mask(bootrom_part_attr_owner_names, value);
+    if (mask == 0xffffffff) {
       perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
       return ERROR_BIF_UNSUPPORTED_VAL;
     }
@@ -492,15 +490,12 @@ error bif_node_set_attr(
         perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
         return ERROR_BIF_PARSER;
       }
-      if (strcmp(value, "ps") == 0)
-        node->destination_device = BOOTROM_PART_ATTR_DEST_DEV_PS;
-      else if (strcmp(value, "pl") == 0)
-        node->destination_device = BOOTROM_PART_ATTR_DEST_DEV_PL;
-      else {
+      mask = map_name_to_mask(bootrom_part_attr_dest_dev_names, value);
+      if (mask == 0xffffffff) {
         perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
         return ERROR_BIF_UNSUPPORTED_VAL;
       }
-
+      node->destination_device = mask;
       return SUCCESS;
     }
 
@@ -509,24 +504,12 @@ error bif_node_set_attr(
         perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
         return ERROR_BIF_PARSER;
       }
-      if (strcmp(value, "a53-0") == 0)
-        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_A53_0;
-      else if (strcmp(value, "a53-1") == 0)
-        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_A53_1;
-      else if (strcmp(value, "a53-2") == 0)
-        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_A53_2;
-      else if (strcmp(value, "a53-3") == 0)
-        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_A53_3;
-      else if (strcmp(value, "r5-0") == 0)
-        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_R5_0;
-      else if (strcmp(value, "r5-1") == 0)
-        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_R5_1;
-      else if (strcmp(value, "r5-lockstep") == 0)
-        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_R5_L;
-      else {
+      mask = map_name_to_mask(bootrom_part_attr_dest_cpu_names, value);
+      if (mask == 0xffffffff) {
         perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
         return ERROR_BIF_UNSUPPORTED_VAL;
       }
+      node->destination_cpu = mask;
       return SUCCESS;
     }
 
@@ -535,18 +518,12 @@ error bif_node_set_attr(
         perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
         return ERROR_BIF_PARSER;
       }
-      if (strcmp(value, "el-0") == 0)
-        node->exception_level = BOOTROM_PART_ATTR_EXC_LVL_EL0;
-      else if (strcmp(value, "el-1") == 0)
-        node->exception_level = BOOTROM_PART_ATTR_EXC_LVL_EL1;
-      else if (strcmp(value, "el-2") == 0)
-        node->exception_level = BOOTROM_PART_ATTR_EXC_LVL_EL2;
-      else if (strcmp(value, "el-3") == 0)
-        node->exception_level = BOOTROM_PART_ATTR_EXC_LVL_EL3;
-      else {
+      mask = map_name_to_mask(bootrom_part_attr_exc_lvl_names, value);
+      if (mask == 0xffffffff) {
         perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
         return ERROR_BIF_UNSUPPORTED_VAL;
       }
+      node->exception_level = mask;
       return SUCCESS;
     }
   }

--- a/src/bif.c
+++ b/src/bif.c
@@ -32,6 +32,7 @@
 #include <string.h>
 
 #include <bif.h>
+#include <bootrom.h>
 #include <common.h>
 #include <ctype.h>
 #include <errno.h>
@@ -331,10 +332,10 @@ static error bif_parse_file(lexer_t *lex, bif_cfg_t *cfg, bif_node_t *node) {
   node->bootloader = 0;
   node->fsbl_config = 0;
   node->pmufw_image = 0;
-  node->exception_level = EL_UNDEF;
-  node->partition_owner = OWNER_FSBL;
-  node->destination_cpu = DST_CPU_UNDEF;
-  node->destination_device = DST_DEV_UNDEF;
+  node->exception_level = BOOTROM_PART_ATTR_EXC_LVL_EL0;
+  node->partition_owner = BOOTROM_PART_ATTR_OWNER_FSBL;
+  node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_NONE;
+  node->destination_device = BOOTROM_PART_ATTR_DEST_DEV_NONE;
   node->is_file = 1;
 
   /* Parse the attribute list if it's present */
@@ -461,9 +462,9 @@ error bif_node_set_attr(
       return ERROR_BIF_PARSER;
     }
     if (strcmp(value, "fsbl") == 0)
-      node->partition_owner = OWNER_FSBL;
+      node->partition_owner = BOOTROM_PART_ATTR_OWNER_FSBL;
     else if (strcmp(value, "uboot") == 0)
-      node->partition_owner = OWNER_UBOOT;
+      node->partition_owner = BOOTROM_PART_ATTR_OWNER_UBOOT;
     else {
       perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
       return ERROR_BIF_UNSUPPORTED_VAL;
@@ -492,9 +493,9 @@ error bif_node_set_attr(
         return ERROR_BIF_PARSER;
       }
       if (strcmp(value, "ps") == 0)
-        node->destination_device = DST_DEV_PS;
+        node->destination_device = BOOTROM_PART_ATTR_DEST_DEV_PS;
       else if (strcmp(value, "pl") == 0)
-        node->destination_device = DST_DEV_PL;
+        node->destination_device = BOOTROM_PART_ATTR_DEST_DEV_PL;
       else {
         perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
         return ERROR_BIF_UNSUPPORTED_VAL;
@@ -509,19 +510,19 @@ error bif_node_set_attr(
         return ERROR_BIF_PARSER;
       }
       if (strcmp(value, "a53-0") == 0)
-        node->destination_cpu = DST_CPU_A53_0;
+        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_A53_0;
       else if (strcmp(value, "a53-1") == 0)
-        node->destination_cpu = DST_CPU_A53_1;
+        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_A53_1;
       else if (strcmp(value, "a53-2") == 0)
-        node->destination_cpu = DST_CPU_A53_2;
+        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_A53_2;
       else if (strcmp(value, "a53-3") == 0)
-        node->destination_cpu = DST_CPU_A53_3;
+        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_A53_3;
       else if (strcmp(value, "r5-0") == 0)
-        node->destination_cpu = DST_CPU_R5_0;
+        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_R5_0;
       else if (strcmp(value, "r5-1") == 0)
-        node->destination_cpu = DST_CPU_R5_1;
+        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_R5_1;
       else if (strcmp(value, "r5-lockstep") == 0)
-        node->destination_cpu = DST_CPU_R5_LOCKSTEP;
+        node->destination_cpu = BOOTROM_PART_ATTR_DEST_CPU_R5_L;
       else {
         perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
         return ERROR_BIF_UNSUPPORTED_VAL;
@@ -535,13 +536,13 @@ error bif_node_set_attr(
         return ERROR_BIF_PARSER;
       }
       if (strcmp(value, "el-0") == 0)
-        node->exception_level = EL_0;
+        node->exception_level = BOOTROM_PART_ATTR_EXC_LVL_EL0;
       else if (strcmp(value, "el-1") == 0)
-        node->exception_level = EL_1;
+        node->exception_level = BOOTROM_PART_ATTR_EXC_LVL_EL1;
       else if (strcmp(value, "el-2") == 0)
-        node->exception_level = EL_2;
+        node->exception_level = BOOTROM_PART_ATTR_EXC_LVL_EL2;
       else if (strcmp(value, "el-3") == 0)
-        node->exception_level = EL_3;
+        node->exception_level = BOOTROM_PART_ATTR_EXC_LVL_EL3;
       else {
         perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
         return ERROR_BIF_UNSUPPORTED_VAL;

--- a/src/bif.c
+++ b/src/bif.c
@@ -37,8 +37,6 @@
 #include <ctype.h>
 #include <errno.h>
 
-/* TODO: panic mode support */
-
 static int perrorf(lexer_t *lex, const char *fmt, ...);
 
 static inline char *get_token_name(int type);
@@ -212,7 +210,7 @@ static error bif_scan(lexer_t *lex) {
   /* Scan a single token from a BIF file */
 
   int ch = 0, prev, err;
-  bool esc = 0;
+  bool esc = false;
 
   /* Skip white chars and comments */
   for (;;) {

--- a/src/bif.h
+++ b/src/bif.h
@@ -11,40 +11,6 @@
 #define BIF_ARCH_ZYNQ   (1 << 0)
 #define BIF_ARCH_ZYNQMP (1 << 1)
 
-typedef enum partition_owner_e
-{
-  OWNER_FSBL,
-  OWNER_UBOOT
-} partition_owner_t;
-
-typedef enum destination_device_e
-{
-  DST_DEV_UNDEF = -1,
-  DST_DEV_PS,
-  DST_DEV_PL
-} destination_device_t;
-
-typedef enum destination_cpu_e
-{
-  DST_CPU_UNDEF = -1,
-  DST_CPU_A53_0,
-  DST_CPU_A53_1,
-  DST_CPU_A53_2,
-  DST_CPU_A53_3,
-  DST_CPU_R5_0,
-  DST_CPU_R5_1,
-  DST_CPU_R5_LOCKSTEP
-} destination_cpu_t;
-
-typedef enum exception_level_e
-{
-  EL_UNDEF = -1,
-  EL_0,
-  EL_1,
-  EL_2,
-  EL_3
-} exception_level_t;
-
 enum token_type
 {
   TOKEN_EOF = 0,
@@ -73,14 +39,14 @@ typedef struct bif_node_t {
   uint8_t bootloader; /* boolean */
   uint32_t load;
   uint32_t offset;
-  partition_owner_t partition_owner;
+  uint32_t partition_owner;
 
   /* supported zynqmp attributes */
   uint8_t fsbl_config; /* boolean */
   uint8_t pmufw_image; /* boolean */
-  destination_device_t destination_device;
-  destination_cpu_t destination_cpu;
-  exception_level_t exception_level;
+  uint32_t destination_device;
+  uint32_t destination_cpu;
+  uint32_t exception_level;
 
   /* special, non-bootgen features */
   uint8_t is_file; /* for now equal to !fsbl_config */

--- a/src/bootrom.c
+++ b/src/bootrom.c
@@ -41,6 +41,82 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+mask_name_t bootrom_part_attr_owner_names[] = {
+  {"fsbl", BOOTROM_PART_ATTR_OWNER_FSBL},
+  {"uboot", BOOTROM_PART_ATTR_OWNER_UBOOT},
+  {0},
+};
+
+mask_name_t bootrom_part_attr_rsa_used_names[] = {
+  {"used", BOOTROM_PART_ATTR_RSA_USED},
+  {"not used", BOOTROM_PART_ATTR_RSA_NOT_USED},
+  {0},
+};
+
+mask_name_t bootrom_part_attr_dest_cpu_names[] = {
+  {"none", BOOTROM_PART_ATTR_DEST_CPU_NONE},
+  {"a53-0", BOOTROM_PART_ATTR_DEST_CPU_A53_0},
+  {"a53-1", BOOTROM_PART_ATTR_DEST_CPU_A53_1},
+  {"a53-2", BOOTROM_PART_ATTR_DEST_CPU_A53_2},
+  {"a53-3", BOOTROM_PART_ATTR_DEST_CPU_A53_3},
+  {"r5-0", BOOTROM_PART_ATTR_DEST_CPU_R5_0},
+  {"r5-1", BOOTROM_PART_ATTR_DEST_CPU_R5_1},
+  {"r5-lockstep", BOOTROM_PART_ATTR_DEST_CPU_R5_L},
+  {0},
+};
+
+mask_name_t bootrom_part_attr_encryption_names[] = {
+  {"yes", BOOTROM_PART_ATTR_ENCRYPTION_YES},
+  {"no", BOOTROM_PART_ATTR_ENCRYPTION_NO},
+  {0},
+};
+
+mask_name_t bootrom_part_attr_dest_dev_names[] = {
+  {"none", BOOTROM_PART_ATTR_DEST_DEV_NONE},
+  {"ps", BOOTROM_PART_ATTR_DEST_DEV_PS},
+  {"pl", BOOTROM_PART_ATTR_DEST_DEV_PL},
+  {"int", BOOTROM_PART_ATTR_DEST_DEV_INT},
+  {0},
+};
+
+mask_name_t bootrom_part_attr_exec_s_names[] = {
+  {"32-bit", BOOTROM_PART_ATTR_A5X_EXEC_S_32},
+  {"64-bit", BOOTROM_PART_ATTR_A5X_EXEC_S_64},
+  {0},
+};
+
+mask_name_t bootrom_part_attr_exc_lvl_names[] = {
+  {"el-0", BOOTROM_PART_ATTR_EXC_LVL_EL0},
+  {"el-1", BOOTROM_PART_ATTR_EXC_LVL_EL1},
+  {"el-2", BOOTROM_PART_ATTR_EXC_LVL_EL2},
+  {"el-3", BOOTROM_PART_ATTR_EXC_LVL_EL3},
+  {0},
+};
+
+mask_name_t bootrom_part_attr_trust_zone_names[] = {
+  {"yes", BOOTROM_PART_ATTR_TRUST_ZONE_YES},
+  {"no", BOOTROM_PART_ATTR_TRUST_ZONE_NO},
+  {0},
+};
+
+uint32_t map_name_to_mask(mask_name_t mask_names[], char *name) {
+  int i;
+
+  for (i = 0; mask_names[i].name; i++)
+    if (strcmp(mask_names[i].name, name) == 0)
+      return mask_names[i].mask;
+  return -1; /* 0xffffffff */
+}
+
+char *map_mask_to_name(mask_name_t mask_names[], uint32_t mask) {
+  int i;
+
+  for (i = 0; mask_names[i].name; i++)
+    if (mask_names[i].mask == mask)
+      return mask_names[i].name;
+  return NULL;
+}
+
 /* Returns the offset by which the addr parameter should be moved
  * and partition header info via argument pointers.
  * The regular return value is the error code. */

--- a/src/bootrom.c
+++ b/src/bootrom.c
@@ -41,63 +41,77 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+/* clang-format off */
 mask_name_t bootrom_part_attr_owner_names[] = {
-  {"fsbl", BOOTROM_PART_ATTR_OWNER_FSBL},
-  {"uboot", BOOTROM_PART_ATTR_OWNER_UBOOT},
+  {"fsbl",  BOOTROM_PART_ATTR_OWNER_FSBL,  NULL},
+  {"uboot", BOOTROM_PART_ATTR_OWNER_UBOOT, NULL},
   {0},
 };
 
 mask_name_t bootrom_part_attr_rsa_used_names[] = {
-  {"used", BOOTROM_PART_ATTR_RSA_USED},
-  {"not used", BOOTROM_PART_ATTR_RSA_NOT_USED},
+  {"used",     BOOTROM_PART_ATTR_RSA_USED,     NULL},
+  {"not used", BOOTROM_PART_ATTR_RSA_NOT_USED, NULL},
   {0},
 };
 
 mask_name_t bootrom_part_attr_dest_cpu_names[] = {
-  {"none", BOOTROM_PART_ATTR_DEST_CPU_NONE},
-  {"a53-0", BOOTROM_PART_ATTR_DEST_CPU_A53_0},
-  {"a53-1", BOOTROM_PART_ATTR_DEST_CPU_A53_1},
-  {"a53-2", BOOTROM_PART_ATTR_DEST_CPU_A53_2},
-  {"a53-3", BOOTROM_PART_ATTR_DEST_CPU_A53_3},
-  {"r5-0", BOOTROM_PART_ATTR_DEST_CPU_R5_0},
-  {"r5-1", BOOTROM_PART_ATTR_DEST_CPU_R5_1},
-  {"r5-lockstep", BOOTROM_PART_ATTR_DEST_CPU_R5_L},
+  {"none",        BOOTROM_PART_ATTR_DEST_CPU_NONE,  NULL},
+  {"a53-0",       BOOTROM_PART_ATTR_DEST_CPU_A53_0, NULL},
+  {"a53-1",       BOOTROM_PART_ATTR_DEST_CPU_A53_1, NULL},
+  {"a53-2",       BOOTROM_PART_ATTR_DEST_CPU_A53_2, NULL},
+  {"a53-3",       BOOTROM_PART_ATTR_DEST_CPU_A53_3, NULL},
+  {"r5-0",        BOOTROM_PART_ATTR_DEST_CPU_R5_0,  NULL},
+  {"r5-1",        BOOTROM_PART_ATTR_DEST_CPU_R5_1,  NULL},
+  {"r5-lockstep", BOOTROM_PART_ATTR_DEST_CPU_R5_L,  NULL},
   {0},
 };
 
 mask_name_t bootrom_part_attr_encryption_names[] = {
-  {"yes", BOOTROM_PART_ATTR_ENCRYPTION_YES},
-  {"no", BOOTROM_PART_ATTR_ENCRYPTION_NO},
+  {"yes", BOOTROM_PART_ATTR_ENCRYPTION_YES, NULL},
+  {"no",  BOOTROM_PART_ATTR_ENCRYPTION_NO,  NULL},
   {0},
 };
 
 mask_name_t bootrom_part_attr_dest_dev_names[] = {
-  {"none", BOOTROM_PART_ATTR_DEST_DEV_NONE},
-  {"ps", BOOTROM_PART_ATTR_DEST_DEV_PS},
-  {"pl", BOOTROM_PART_ATTR_DEST_DEV_PL},
-  {"int", BOOTROM_PART_ATTR_DEST_DEV_INT},
+  {"none", BOOTROM_PART_ATTR_DEST_DEV_NONE, NULL},
+  {"ps",   BOOTROM_PART_ATTR_DEST_DEV_PS,   NULL},
+  {"pl",   BOOTROM_PART_ATTR_DEST_DEV_PL,   NULL},
+  {"int",  BOOTROM_PART_ATTR_DEST_DEV_INT,  NULL},
   {0},
 };
 
-mask_name_t bootrom_part_attr_exec_s_names[] = {
-  {"32-bit", BOOTROM_PART_ATTR_A5X_EXEC_S_32},
-  {"64-bit", BOOTROM_PART_ATTR_A5X_EXEC_S_64},
+mask_name_t bootrom_part_attr_a5x_exec_s_names[] = {
+  {"32-bit", BOOTROM_PART_ATTR_A5X_EXEC_S_32, NULL},
+  {"64-bit", BOOTROM_PART_ATTR_A5X_EXEC_S_64, NULL},
   {0},
 };
 
 mask_name_t bootrom_part_attr_exc_lvl_names[] = {
-  {"el-0", BOOTROM_PART_ATTR_EXC_LVL_EL0},
-  {"el-1", BOOTROM_PART_ATTR_EXC_LVL_EL1},
-  {"el-2", BOOTROM_PART_ATTR_EXC_LVL_EL2},
-  {"el-3", BOOTROM_PART_ATTR_EXC_LVL_EL3},
+  {"el-0", BOOTROM_PART_ATTR_EXC_LVL_EL0, NULL},
+  {"el-1", BOOTROM_PART_ATTR_EXC_LVL_EL1, NULL},
+  {"el-2", BOOTROM_PART_ATTR_EXC_LVL_EL2, NULL},
+  {"el-3", BOOTROM_PART_ATTR_EXC_LVL_EL3, NULL},
   {0},
 };
 
 mask_name_t bootrom_part_attr_trust_zone_names[] = {
-  {"yes", BOOTROM_PART_ATTR_TRUST_ZONE_YES},
-  {"no", BOOTROM_PART_ATTR_TRUST_ZONE_NO},
+  {"yes", BOOTROM_PART_ATTR_TRUST_ZONE_YES, NULL},
+  {"no",  BOOTROM_PART_ATTR_TRUST_ZONE_NO,  NULL},
   {0},
 };
+
+mask_name_t bootrom_part_attr_mask_names[] = {
+  {"Owner",               BOOTROM_PART_ATTR_OWNER_MASK,      bootrom_part_attr_owner_names},
+  {"RSA",                 BOOTROM_PART_ATTR_RSA_USED_MASK,   bootrom_part_attr_rsa_used_names},
+  {"Destination CPU",     BOOTROM_PART_ATTR_DEST_CPU_MASK,   bootrom_part_attr_dest_cpu_names},
+  {"Encryption",          BOOTROM_PART_ATTR_ENCRYPTION_MASK, bootrom_part_attr_encryption_names},
+  {"Destination Device",  BOOTROM_PART_ATTR_DEST_DEV_MASK,   bootrom_part_attr_dest_dev_names},
+  {"A5x Execution State", BOOTROM_PART_ATTR_A5X_EXEC_S_MASK, bootrom_part_attr_a5x_exec_s_names},
+  {"Exception Level",     BOOTROM_PART_ATTR_EXC_LVL_MASK,    bootrom_part_attr_exc_lvl_names},
+  {"Trust Zone",          BOOTROM_PART_ATTR_TRUST_ZONE_MASK, bootrom_part_attr_trust_zone_names},
+  {0}
+};
+/* clang-format on */
 
 uint32_t map_name_to_mask(mask_name_t mask_names[], char *name) {
   int i;
@@ -105,7 +119,7 @@ uint32_t map_name_to_mask(mask_name_t mask_names[], char *name) {
   for (i = 0; mask_names[i].name; i++)
     if (strcmp(mask_names[i].name, name) == 0)
       return mask_names[i].mask;
-  return -1; /* 0xffffffff */
+  return 0xffffffff;
 }
 
 char *map_mask_to_name(mask_name_t mask_names[], uint32_t mask) {
@@ -114,7 +128,7 @@ char *map_mask_to_name(mask_name_t mask_names[], uint32_t mask) {
   for (i = 0; mask_names[i].name; i++)
     if (mask_names[i].mask == mask)
       return mask_names[i].name;
-  return NULL;
+  return "INVALID";
 }
 
 /* Returns the offset by which the addr parameter should be moved

--- a/src/bootrom.c
+++ b/src/bootrom.c
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/bootrom.c
+++ b/src/bootrom.c
@@ -120,7 +120,7 @@ uint32_t map_name_to_mask(mask_name_t mask_names[], char *name) {
   for (i = 0; mask_names[i].name; i++)
     if (strcmp(mask_names[i].name, name) == 0)
       return mask_names[i].mask;
-  return 0xffffffff;
+  return NOMASK;
 }
 
 char *map_mask_to_name(mask_name_t mask_names[], uint32_t mask) {

--- a/src/bootrom.h
+++ b/src/bootrom.h
@@ -4,6 +4,8 @@
 #include <bif.h>
 #include <gelf.h>
 
+#define NOMASK 0xFFFFFFFF
+
 /* BootROM Header based on ug585 and ug1085 */
 typedef struct bootrom_hdr_t {
   uint32_t interrupt_table[8];

--- a/src/bootrom.h
+++ b/src/bootrom.h
@@ -144,6 +144,7 @@ typedef struct linux_image_header_t {
 #define BOOTROM_PART_ATTR_RSA_NOT_USED  (0 << BOOTROM_PART_ATTR_RSA_USED_OFF)
 
 #define BOOTROM_PART_ATTR_DEST_CPU_OFF   8
+#define BOOTROM_PART_ATTR_DEST_CPU_MASK  (7 << BOOTROM_PART_ATTR_DEST_CPU_OFF)
 #define BOOTROM_PART_ATTR_DEST_CPU_NONE  (0 << BOOTROM_PART_ATTR_DEST_CPU_OFF)
 #define BOOTROM_PART_ATTR_DEST_CPU_A53_0 (1 << BOOTROM_PART_ATTR_DEST_CPU_OFF)
 #define BOOTROM_PART_ATTR_DEST_CPU_A53_1 (2 << BOOTROM_PART_ATTR_DEST_CPU_OFF)
@@ -153,9 +154,10 @@ typedef struct linux_image_header_t {
 #define BOOTROM_PART_ATTR_DEST_CPU_R5_1  (6 << BOOTROM_PART_ATTR_DEST_CPU_OFF)
 #define BOOTROM_PART_ATTR_DEST_CPU_R5_L  (7 << BOOTROM_PART_ATTR_DEST_CPU_OFF)
 
-#define BOOTROM_PART_ATTR_ENCRYPTION_OFF 7
-#define BOOTROM_PART_ATTR_ENCRYPTION_YES (1 << BOOTROM_PART_ATTR_ENCRYPTION_OFF)
-#define BOOTROM_PART_ATTR_ENCRYPTION_NO  (0 << BOOTROM_PART_ATTR_ENCRYPTION_OFF)
+#define BOOTROM_PART_ATTR_ENCRYPTION_OFF  7
+#define BOOTROM_PART_ATTR_ENCRYPTION_MASK (1 << BOOTROM_PART_ATTR_ENCRYPTION_OFF)
+#define BOOTROM_PART_ATTR_ENCRYPTION_YES  (1 << BOOTROM_PART_ATTR_ENCRYPTION_OFF)
+#define BOOTROM_PART_ATTR_ENCRYPTION_NO   (0 << BOOTROM_PART_ATTR_ENCRYPTION_OFF)
 
 #define BOOTROM_PART_ATTR_DEST_DEV_OFF  4
 #define BOOTROM_PART_ATTR_DEST_DEV_MASK (7 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
@@ -164,20 +166,22 @@ typedef struct linux_image_header_t {
 #define BOOTROM_PART_ATTR_DEST_DEV_PL   (2 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
 #define BOOTROM_PART_ATTR_DEST_DEV_INT  (3 << BOOTROM_PART_ATTR_DEST_DEV_OFF)
 
-#define BOOTROM_PART_ATTR_A5X_EXEC_S_OFF 3
-#define BOOTROM_PART_ATTR_A5X_EXEC_S_64  (0 << BOOTROM_PART_ATTR_A5X_EXEC_S_OFF)
-#define BOOTROM_PART_ATTR_A5X_EXEC_S_32  (1 << BOOTROM_PART_ATTR_A5X_EXEC_S_OFF)
+#define BOOTROM_PART_ATTR_A5X_EXEC_S_OFF  3
+#define BOOTROM_PART_ATTR_A5X_EXEC_S_MASK (1 << BOOTROM_PART_ATTR_A5X_EXEC_S_OFF)
+#define BOOTROM_PART_ATTR_A5X_EXEC_S_64   (0 << BOOTROM_PART_ATTR_A5X_EXEC_S_OFF)
+#define BOOTROM_PART_ATTR_A5X_EXEC_S_32   (1 << BOOTROM_PART_ATTR_A5X_EXEC_S_OFF)
 
 #define BOOTROM_PART_ATTR_EXC_LVL_OFF  1
-#define BOOTROM_PART_ATTR_EXC_LVL_MASK (0x3 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
+#define BOOTROM_PART_ATTR_EXC_LVL_MASK (3 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
 #define BOOTROM_PART_ATTR_EXC_LVL_EL0  (0 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
 #define BOOTROM_PART_ATTR_EXC_LVL_EL1  (1 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
 #define BOOTROM_PART_ATTR_EXC_LVL_EL2  (2 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
 #define BOOTROM_PART_ATTR_EXC_LVL_EL3  (3 << BOOTROM_PART_ATTR_EXC_LVL_OFF)
 
-#define BOOTROM_PART_ATTR_TRUST_ZONE_OFF 0
-#define BOOTROM_PART_ATTR_TRUST_ZONE_YES (1 << BOOTROM_PART_ATTR_TRUST_ZONE_OFF)
-#define BOOTROM_PART_ATTR_TRUST_ZONE_NO  (0 << BOOTROM_PART_ATTR_TRUST_ZONE_OFF)
+#define BOOTROM_PART_ATTR_TRUST_ZONE_OFF  0
+#define BOOTROM_PART_ATTR_TRUST_ZONE_MASK (3 << BOOTROM_PART_ATTR_TRUST_ZONE_OFF)
+#define BOOTROM_PART_ATTR_TRUST_ZONE_YES  (1 << BOOTROM_PART_ATTR_TRUST_ZONE_OFF)
+#define BOOTROM_PART_ATTR_TRUST_ZONE_NO   (0 << BOOTROM_PART_ATTR_TRUST_ZONE_OFF)
 
 /* values taken from boot.bin generated with bootgen
  * so there is no understanding of them yet */
@@ -270,6 +274,23 @@ typedef struct bootrom_offs_t {
   uint32_t part_hdr_end_off;
   uint32_t bins_off;
 } bootrom_offs_t;
+
+typedef struct mask_name_t {
+  char *name;
+  uint32_t mask;
+} mask_name_t;
+
+extern mask_name_t bootrom_part_attr_owner_names[];
+extern mask_name_t bootrom_part_attr_rsa_used_names[];
+extern mask_name_t bootrom_part_attr_dest_cpu_names[];
+extern mask_name_t bootrom_part_attr_encryption_names[];
+extern mask_name_t bootrom_part_attr_dest_dev_names[];
+extern mask_name_t bootrom_part_attr_exec_s_names[];
+extern mask_name_t bootrom_part_attr_exc_lvl_names[];
+extern mask_name_t bootrom_part_attr_trust_zone_names[];
+
+uint32_t map_name_to_mask(mask_name_t mask_names[], char *name);
+char *map_mask_to_name(mask_name_t mask_names[], uint32_t mask);
 
 /* bootrom operations */
 typedef struct bootrom_ops_t {

--- a/src/bootrom.h
+++ b/src/bootrom.h
@@ -139,7 +139,7 @@ typedef struct linux_image_header_t {
 #define BOOTROM_PART_ATTR_OWNER_UBOOT (1 << BOOTROM_PART_ATTR_OWNER_OFF)
 
 #define BOOTROM_PART_ATTR_RSA_USED_OFF  15
-#define BOOTROM_PART_ATTR_RSA_USED_MASK (1 << BOOTROM_PATR_ATTR_RSA_USED_OFF)
+#define BOOTROM_PART_ATTR_RSA_USED_MASK (1 << BOOTROM_PART_ATTR_RSA_USED_OFF)
 #define BOOTROM_PART_ATTR_RSA_USED      (1 << BOOTROM_PART_ATTR_RSA_USED_OFF)
 #define BOOTROM_PART_ATTR_RSA_NOT_USED  (0 << BOOTROM_PART_ATTR_RSA_USED_OFF)
 
@@ -278,14 +278,16 @@ typedef struct bootrom_offs_t {
 typedef struct mask_name_t {
   char *name;
   uint32_t mask;
+  struct mask_name_t *submasks;
 } mask_name_t;
 
+extern mask_name_t bootrom_part_attr_mask_names[];
 extern mask_name_t bootrom_part_attr_owner_names[];
 extern mask_name_t bootrom_part_attr_rsa_used_names[];
 extern mask_name_t bootrom_part_attr_dest_cpu_names[];
 extern mask_name_t bootrom_part_attr_encryption_names[];
 extern mask_name_t bootrom_part_attr_dest_dev_names[];
-extern mask_name_t bootrom_part_attr_exec_s_names[];
+extern mask_name_t bootrom_part_attr_a5x_exec_s_names[];
 extern mask_name_t bootrom_part_attr_exc_lvl_names[];
 extern mask_name_t bootrom_part_attr_trust_zone_names[];
 

--- a/src/common.c
+++ b/src/common.c
@@ -38,7 +38,7 @@ int is_postfix(char *string, char *pfix) {
   return strcmp(string + strlen(string) - strlen(pfix), pfix) == 0;
 }
 
-/* Check if a string is present on a list*/
+/* Check if a string is present on a list */
 int is_on_list(char *list[], char *s) {
   int i;
 
@@ -47,3 +47,4 @@ int is_on_list(char *list[], char *s) {
       return 0xFF;
   return 0;
 }
+

--- a/src/common.c
+++ b/src/common.c
@@ -1,4 +1,5 @@
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,17 +35,16 @@ uint32_t calc_checksum(uint32_t *start_addr, uint32_t *end_addr) {
 }
 
 /* Check if pfix is a postifx of string */
-int is_postfix(char *string, char *pfix) {
+bool is_postfix(char *string, char *pfix) {
   return strcmp(string + strlen(string) - strlen(pfix), pfix) == 0;
 }
 
 /* Check if a string is present on a list */
-int is_on_list(char *list[], char *s) {
+bool is_on_list(char *list[], char *s) {
   int i;
 
   for (i = 0; list[i]; i++)
     if (strcmp(list[i], s) == 0)
-      return 0xFF;
-  return 0;
+      return true;
+  return false;
 }
-

--- a/src/common.h
+++ b/src/common.h
@@ -36,7 +36,7 @@ typedef enum error
 
 int errorf(const char *fmt, ...);
 uint32_t calc_checksum(uint32_t *, uint32_t *);
-int is_postfix(char *, char *);
-int is_on_list(char **, char *);
+bool is_postfix(char *, char *);
+bool is_on_list(char **, char *);
 
 #endif

--- a/src/exbootimage.c
+++ b/src/exbootimage.c
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -66,18 +67,17 @@ struct format {
 
 /* Prepare struct for holding parsed arguments */
 struct arguments {
-  uint8_t list;
-  uint8_t describe;
-  uint8_t header;
-  uint8_t images;
-  uint8_t partitions;
-  uint8_t zynqmp;
+  bool list;
+  bool describe;
+  bool header;
+  bool images;
+  bool partitions;
+  bool zynqmp;
 
-  uint8_t force;
-  uint8_t extract;
+  bool force;
+  bool extract;
   int extract_count;
   char **extract_names;
-  uint8_t in_file_list;
 
   char *design;
   char *part;
@@ -263,9 +263,7 @@ int print_attr(FILE *f, void *base, int offset) {
     subm = bootrom_part_attr_mask_names[i].submasks;
 
     print_padding(f, 13, ' ');
-    fprintf(f, "%s: %s",
-      name,
-      map_mask_to_name(subm, attr & mask));
+    fprintf(f, "%s: %s", name, map_mask_to_name(subm, attr & mask));
 
     /* Start a newline if there are more attribute values to be printed */
     if (bootrom_part_attr_mask_names[i + 1].name)
@@ -418,7 +416,7 @@ error print_partition_contents(FILE *f, hdr_t *base, uint32_t size, struct argum
 
     /* Check if the file is fine */
     if (!stat(name, &bstat) && !arguments->force) {
-      errorf("file %s alraedy exists, use -f to force\n", name);
+      errorf("file %s already exists, use -f to force\n", name);
       return ERROR_BIN_FILE_EXISTS;
     }
     if (!(bfile = fopen(name, "wb"))) {
@@ -502,30 +500,30 @@ static error_t argp_parser(int key, char *arg, struct argp_state *state) {
 
   switch (key) {
   case 'u':
-    arguments->zynqmp = 0xFF;
+    arguments->zynqmp = true;
     break;
   case 'x':
-    arguments->extract = 0xFF;
+    arguments->extract = true;
     break;
   case 'f':
-    arguments->force = 0xFF;
+    arguments->force = true;
     break;
   case 'l':
-    arguments->list = 0xFF;
+    arguments->list = true;
     break;
   case 'd':
-    arguments->header = 0xFF;
-    arguments->images = 0xFF;
-    arguments->partitions = 0xFF;
+    arguments->header = true;
+    arguments->images = true;
+    arguments->partitions = true;
     break;
   case 'h':
-    arguments->header = 0xFF;
+    arguments->header = true;
     break;
   case 'i':
-    arguments->images = 0xFF;
+    arguments->images = true;
     break;
   case 'p':
-    arguments->partitions = 0xFF;
+    arguments->partitions = true;
     break;
   case 'b':
     if (!(s = strchr(arg, ',')))

--- a/src/exbootimage.c
+++ b/src/exbootimage.c
@@ -505,9 +505,7 @@ static error verify_waddr(void *base, uint32_t size, uint32_t *poffset) {
   return ERROR_BIN_WADDR;
 }
 
-/* Get next image absolute pointer from next_img_off value
- * The return value is negative on error, positive on end of iteration
- * and zero otherwise. */
+/* Get next image absolute pointer or pointer to the first one if *img is NULL*/
 static error get_next_image(void *base, uint32_t size, img_hdr_t **img) {
   error err;
   img_hdr_tab_t *tab;

--- a/src/file/bitstream.c
+++ b/src/file/bitstream.c
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -68,7 +69,7 @@ int bitstream_write_header_part(FILE *bitfile, const uint8_t tag, const char *da
   return 0;
 }
 
-int bitstream_write_header(FILE *bitfile, uint32_t size, const char *design, const char *part) {
+error bitstream_write_header(FILE *bitfile, uint32_t size, const char *design, const char *part) {
   const uint8_t header[] = {
     0x00,
     0x09,
@@ -124,7 +125,7 @@ int bitstream_write_header(FILE *bitfile, uint32_t size, const char *design, con
     fwrite(&n, sizeof(uint8_t), 1, bitfile);
   }
 
-  return 0;
+  return SUCCESS;
 }
 
 error bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size) {

--- a/src/file/bitstream.h
+++ b/src/file/bitstream.h
@@ -4,7 +4,7 @@
 /* Check if this really is a bitstream file */
 error bitstream_verify(FILE *bitfile);
 
-int bitstream_write_header(FILE *bfile, uint32_t size, const char *design, const char *part);
+error bitstream_write_header(FILE *bfile, uint32_t size, const char *design, const char *part);
 
 /* Returns the appended bitstream size via the last argument.
  * The regular return value is the error code. */

--- a/src/file/elf.c
+++ b/src/file/elf.c
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -33,7 +34,7 @@
 #include <gelf.h>
 #include <unistd.h>
 
-static int elf_is_loadable_section(const GElf_Shdr *elf_shdr) {
+static bool elf_is_loadable_section(const GElf_Shdr *elf_shdr) {
   return elf_shdr->sh_type != SHT_NOBITS && (elf_shdr->sh_flags & SHF_ALLOC) &&
          elf_shdr->sh_size != 0;
 }

--- a/src/mkbootimage.c
+++ b/src/mkbootimage.c
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,10 +49,10 @@ static struct argp_option argp_options[] = {
 
 /* Prapare struct for holding parsed arguments */
 struct arguments {
-  uint8_t zynqmp;
+  bool zynqmp;
+  bool parse_only;
   char *bif_filename;
   char *bin_filename;
-  uint8_t parse_only;
 };
 
 /* Define argument parser */
@@ -60,10 +61,10 @@ static error_t argp_parser(int key, char *arg, struct argp_state *state) {
 
   switch (key) {
   case 'u':
-    arguments->zynqmp = 0xFF;
+    arguments->zynqmp = true;
     break;
   case 'p':
-    arguments->parse_only = 0xFF;
+    arguments->parse_only = true;
     break;
   case ARGP_KEY_ARG:
     switch (state->arg_num) {
@@ -105,8 +106,7 @@ int main(int argc, char *argv[]) {
   int i;
 
   /* Init non-string arguments */
-  arguments.zynqmp = 0;
-  arguments.parse_only = 0;
+  memset(&arguments, 0, sizeof(arguments));
 
   /* Parse program arguments */
   argp_parse(&argp, argc, argv, 0, 0, &arguments);


### PR DESCRIPTION
The simplifications come mainly from generelization of similar actions done in `mkbootimage` and `exbootimage`.

The types mentioned in the commit title are mainly insertions of `bool` and `error` in parts of the code when they hadn't been present yet.
