### PR TITLE
add portablity fixes for OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .PHONY: all clean distclean
 
-CC=gcc
+CC?=cc
 
 FMT=clang-format
+
+osname != uname
 
 MKBOOTIMAGE_NAME:=mkbootimage
 EXBOOTIMAGE_NAME:=exbootimage
@@ -28,13 +30,19 @@ ALL_SRCS:=$(COMMON_SRCS) src/mkbootimage.c src/exbootimage.c
 ALL_HDRS:=$(COMMON_HDRS)
 
 INCLUDE_DIRS:=src
+ifeq ($(osname), OpenBSD)
+	INCLUDE_DIRS:=src /usr/local/include
+endif
 
 override CFLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir)) \
 	-DMKBOOTIMAGE_VER="\"$(VERSION)\"" \
 	-Wall -Wextra -Wpedantic \
 	--std=c11
 
-LDLIBS = -lelf
+LDLIBS ?= -lelf
+ifeq ($(osname), OpenBSD)
+	LDLIBS += -lelf -L/usr/local/lib -largp
+endif
 
 all: $(MKBOOTIMAGE_NAME) $(EXBOOTIMAGE_NAME)
 

--- a/src/bif.h
+++ b/src/bif.h
@@ -6,7 +6,11 @@
 #include <string.h>
 
 #include <common.h>
+#ifdef __linux__
 #include <linux/limits.h>
+#elif __OpenBSD__
+#include <sys/syslimits.h>
+#endif
 
 #define BIF_ARCH_ZYNQ   (1 << 0)
 #define BIF_ARCH_ZYNQMP (1 << 1)

--- a/src/bootrom.c
+++ b/src/bootrom.c
@@ -33,7 +33,9 @@
 #include <arch/common.h>
 #include <bif.h>
 #include <bootrom.h>
+#ifdef __limux
 #include <byteswap.h>
+#endif
 #include <common.h>
 #include <fcntl.h>
 #include <file/bitstream.h>


### PR DESCRIPTION
Tested on OpenBSD 7.9 (with base's `clang`) and archlinux with `gcc`.

OpenBSD:
```
$ clang -v
OpenBSD clang version 19.1.7
Target: amd64-unknown-openbsd7.9
Thread model: posix
InstalledDir: /usr/bin

```

Linux:
```
gcc version 16.1.1 20260430 (GCC)
```

`argp-standalone` need to be also installed on OpenBSD as well.