### PR TITLE
add raw .bin file support on mkbootimage

### DIFF
--- a/src/bif.c
+++ b/src/bif.c
@@ -475,6 +475,20 @@ error bif_node_set_attr(
     return SUCCESS;
   }
 
+  if (strcmp(attr_name, "destination_device") == 0) {
+    if (!value) {
+      perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
+      return ERROR_BIF_PARSER;
+    }
+    mask = map_name_to_mask(bootrom_part_attr_dest_dev_names, value);
+    if (mask == NOMASK) {
+      perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
+      return ERROR_BIF_UNSUPPORTED_VAL;
+    }
+    node->destination_device = mask;
+    return SUCCESS;
+  }
+
   /* Only handle these for zynqmp arch */
   if (cfg->arch & BIF_ARCH_ZYNQMP) {
     if (strcmp(attr_name, "fsbl_config") == 0) {
@@ -487,20 +501,6 @@ error bif_node_set_attr(
 
     if (strcmp(attr_name, "pmufw_image") == 0) {
       node->pmufw_image = 0xFF;
-      return SUCCESS;
-    }
-
-    if (strcmp(attr_name, "destination_device") == 0) {
-      if (!value) {
-        perrorf(lex, "the \"%s\" attribute requires an argument\n", attr_name);
-        return ERROR_BIF_PARSER;
-      }
-      mask = map_name_to_mask(bootrom_part_attr_dest_dev_names, value);
-      if (mask == NOMASK) {
-        perrorf(lex, "value: \"%s\" not supported for the \"%s\" attribute\n", value, attr_name);
-        return ERROR_BIF_UNSUPPORTED_VAL;
-      }
-      node->destination_device = mask;
       return SUCCESS;
     }
 

--- a/src/bootrom.c
+++ b/src/bootrom.c
@@ -243,12 +243,24 @@ error append_file_to_image(uint32_t *addr,
 
     bops->init_part_hdr_dtb(part_hdr, &node);
     break;
-  default: /* Treat as a binary file */
-
-    fseek(cfile, 0, SEEK_SET);
-    *img_size = fread(addr, 1, cfile_stat.st_size, cfile);
-
-    bops->init_part_hdr_default(part_hdr, &node);
+  default: /* Treat as a binary file
+              FPGA bitstream. Convert binary file 32-bit word byte
+              order in the sameway as the payload extracted
+              from a Xilinx .bit file.
+            */
+    if (node.destination_device == BOOTROM_PART_ATTR_DEST_DEV_PL) {
+      err = bitstream_bin_append(addr, cfile, img_size);
+      if (err) {
+        errorf("raw bitstream reading failed: %s\n", node.fname);
+        fclose(cfile);
+        return err;
+      }
+      bops->init_part_hdr_bitstream(part_hdr, &node);
+    } else {
+      fseek(cfile, 0, SEEK_SET);
+      *img_size = fread(addr, 1, cfile_stat.st_size, cfile);
+      bops->init_part_hdr_default(part_hdr, &node);
+    }
   };
 
   *img_size += img_size_init;

--- a/src/file/bitstream.c
+++ b/src/file/bitstream.c
@@ -179,3 +179,44 @@ error bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size) {
 
   return SUCCESS;
 }
+
+error bitstream_bin_append(uint32_t *addr, FILE *binfile, uint32_t *img_size) {
+  uint32_t *dest = addr;
+  uint32_t chunk, rchunk;
+  long file_size;
+  unsigned int i;
+
+  /* Determine raw bitstream size */
+  if (fseek(binfile, 0, SEEK_END) != 0) {
+    errorf("could not seek raw bitstream file.\n");
+    return ERROR_BOOTROM_BITSTREAM;
+  }
+
+  file_size = ftell(binfile);
+  if (file_size < 0) {
+    errorf("could not determine raw bitstream size.\n");
+    return ERROR_BOOTROM_BITSTREAM;
+  }
+
+  if ((file_size % sizeof(uint32_t)) != 0) {
+    errorf("raw bitstream size is not a multiple of 4 bytes.\n");
+    return ERROR_BOOTROM_BITSTREAM;
+  }
+
+  rewind(binfile);
+
+  *img_size = (uint32_t) file_size;
+
+  for (i = 0; i < *img_size; i += sizeof(chunk)) {
+    if (fread(&chunk, 1, sizeof(chunk), binfile) != sizeof(chunk)) {
+      errorf("could not read raw bitstream data.\n");
+      return ERROR_BOOTROM_BITSTREAM;
+    }
+
+    rchunk = __builtin_bswap32(chunk);
+    memcpy(dest, &rchunk, sizeof(rchunk));
+    dest++;
+  }
+
+  return SUCCESS;
+}

--- a/src/file/bitstream.h
+++ b/src/file/bitstream.h
@@ -11,4 +11,10 @@ error bitstream_write(FILE *bfile, uint32_t size, uint32_t *data);
  * The regular return value is the error code. */
 error bitstream_append(uint32_t *addr, FILE *bitfile, uint32_t *img_size);
 
+/* Append a raw binary bitstream.
+   Unlike bitstream_append(), this input has no Xilinx .bit header.
+   The binary contains the FPGA configuration payload directly, so
+   only the 32-bit word byte swapping is required. */
+error bitstream_bin_append(uint32_t *addr, FILE *binfile, uint32_t *img_size);
+
 #endif


### PR DESCRIPTION
Add a patch to ``zynq-mkbootimage`` to support using raw .bin boot images.

``zynq-mkbootimage`` expected a .bit file, from which it extracted and converted the bitstream. Raw .bin bitstreams were instead treated as generic binary files and could not be used directly for the PL.

The patch:
- Enables the destination_device=pl BIF attribute for Zynq-7000.
- Support processing raw binary bitstreams.

This allows boot images to be generated directly from vivado .bin bitstreams, e.g.:
``[destination_device=pl]top.bin``